### PR TITLE
Control plane: hierarchical daemon + shared agent registry

### DIFF
--- a/MCP/nemesis8-orchestrator.py
+++ b/MCP/nemesis8-orchestrator.py
@@ -456,5 +456,76 @@ async def pokeball_list_community() -> Dict[str, Any]:
     }
 
 
+# ── agent_* (fleet control via the gateway control plane) ─────────
+
+
+@mcp.tool()
+async def agent_list() -> Dict[str, Any]:
+    """List every agent the control plane knows about — local and, if this
+    gateway is a controller, agents reported by worker daemons too.
+
+    Returns each agent's id ({host_id}/{local_id}), provider, state
+    (starting/running/idle/exited/killed), source (spawned/discovered/
+    registered), container, and workspace.
+    """
+    logger.info("agent_list")
+    return _gateway_request("GET", "/agents")
+
+
+@mcp.tool()
+async def agent_get(agent_id: str) -> Dict[str, Any]:
+    """Get one agent's full record. agent_id may be the local id, the global
+    {host_id}/{local_id}, or a unique prefix."""
+    logger.info("agent_get %s", agent_id)
+    return _gateway_request("GET", f"/agents/{agent_id}")
+
+
+@mcp.tool()
+async def agent_spawn(prompt: str, provider: Optional[str] = None) -> Dict[str, Any]:
+    """Launch a new agent with a one-shot prompt. The control plane starts a
+    fresh container; it appears in agent_list within one reconcile tick.
+
+    Args:
+        prompt: The prompt to run.
+        provider: Optional provider override (codex, gemini, claude,
+            antigravity, ...). Defaults to the gateway's configured provider.
+    """
+    logger.info("agent_spawn provider=%s", provider)
+    body: Dict[str, Any] = {"prompt": prompt}
+    if provider:
+        body["provider"] = provider
+    return _gateway_request("POST", "/agents/spawn", body=body)
+
+
+@mcp.tool()
+async def agent_kill(agent_id: str) -> Dict[str, Any]:
+    """Stop an agent and mark it killed. Cross-host kills route through the
+    owning worker daemon. agent_id may be local id, global id, or prefix."""
+    logger.info("agent_kill %s", agent_id)
+    return _gateway_request("POST", f"/agents/{agent_id}/kill")
+
+
+@mcp.tool()
+async def agent_events(tail: int = 50) -> Dict[str, Any]:
+    """Recent telemetry events (filesystem/network/heartbeat) from the
+    monitor stream. Returns the last `tail` events.
+    """
+    logger.info("agent_events tail=%d", tail)
+    result = _gateway_request("GET", "/monitor/events")
+    if result.get("success") and isinstance(result.get("data"), list):
+        events = result["data"]
+        result["data"] = events[-tail:] if tail > 0 else events
+        result["count"] = len(result["data"])
+    return result
+
+
+@mcp.tool()
+async def daemon_list() -> Dict[str, Any]:
+    """List worker daemons registered with this controller (the fleet's
+    hosts). Empty on a standalone gateway."""
+    logger.info("daemon_list")
+    return _gateway_request("GET", "/daemons")
+
+
 if __name__ == "__main__":
     mcp.run()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,12 @@ pub enum Command {
         id: String,
     },
 
+    /// Fleet control: list / kill / spawn agents across the control plane
+    Agents {
+        #[command(subcommand)]
+        action: Option<AgentsAction>,
+    },
+
     /// Sealed containers: capture, build, run, publish
     Pokeball {
         #[command(subcommand)]
@@ -186,6 +192,20 @@ pub enum MountAction {
     },
     /// List current mount points
     List,
+}
+
+#[derive(Subcommand)]
+pub enum AgentsAction {
+    /// List all agents the control plane knows about (default)
+    List,
+    /// Kill an agent by id (local_id, global host/local, or prefix)
+    Kill {
+        id: String,
+    },
+    /// Spawn a new agent with a one-shot prompt
+    Spawn {
+        prompt: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,19 @@ pub enum Command {
     Interactive,
 
     /// Start the HTTP gateway + scheduler
-    Serve,
+    Serve {
+        /// Detach and run in the background (writes a PID + log file)
+        #[arg(long)]
+        background: bool,
+
+        /// Show whether the background gateway is running, then exit
+        #[arg(long)]
+        status: bool,
+
+        /// Stop the background gateway, then exit
+        #[arg(long)]
+        stop: bool,
+    },
 
     /// Drop into a container bash shell
     Shell,

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,35 @@ pub struct Config {
     /// Integrations — auto-connect to running services
     #[serde(default)]
     pub integrations: Integrations,
+
+    /// Control-plane role + topology (hierarchical fleet). Absent = standalone.
+    #[serde(default)]
+    pub control_plane: Option<ControlPlane>,
+}
+
+/// Hierarchical control-plane configuration.
+///
+/// - `role = "controller"` (default if section present): this daemon holds the
+///   fleet registry; workers register up to it.
+/// - `role = "worker"`: this daemon manages local agents and pushes them up to
+///   `controller_url`.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ControlPlane {
+    /// "controller" or "worker".
+    #[serde(default = "default_role")]
+    pub role: String,
+
+    /// For workers: the controller's base URL (e.g. http://workstation:4000).
+    #[serde(default)]
+    pub controller_url: Option<String>,
+
+    /// Stable host id. Defaults to the machine hostname when omitted.
+    #[serde(default)]
+    pub host_id: Option<String>,
+}
+
+fn default_role() -> String {
+    "controller".to_string()
 }
 
 /// Auto-discovery integrations
@@ -170,6 +199,7 @@ impl Default for Config {
             remote: None,
             remote_token: None,
             integrations: Integrations::default(),
+            control_plane: None,
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,142 @@
+//! Daemon-mode helpers for `n8 serve`.
+//!
+//! `n8 serve` runs the gateway in the foreground by default. These helpers add
+//! a first-class background mode so the control plane can run without a
+//! babysitting terminal:
+//!   - `spawn_background` — re-spawn this exe as a detached `serve` process,
+//!     redirect its output to a log file, record its PID.
+//!   - `status` — report whether the gateway is up (PID file + /health probe).
+//!   - `stop` — terminate the recorded PID.
+//!
+//! State lives under ~/.codex-service/ (same dir as the trigger store):
+//!   gateway.pid, gateway.log
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+fn service_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".codex-service")
+}
+
+pub fn pid_path() -> PathBuf {
+    service_dir().join("gateway.pid")
+}
+
+pub fn log_path() -> PathBuf {
+    service_dir().join("gateway.log")
+}
+
+fn read_pid() -> Option<u32> {
+    std::fs::read_to_string(pid_path())
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+/// Re-spawn this executable as a detached `serve` process (without
+/// `--background`, so no recursion), redirect its stdout/stderr to the log
+/// file, and record its PID. The parent returns immediately.
+pub fn spawn_background(port: u16) -> Result<()> {
+    let dir = service_dir();
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path())
+        .with_context(|| format!("opening {}", log_path().display()))?;
+    let log_err = log.try_clone()?;
+
+    let exe = std::env::current_exe().context("resolving current exe")?;
+
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("serve")
+        .arg("--port")
+        .arg(port.to_string())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err));
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // New process group so the daemon survives the parent shell and isn't
+        // killed by terminal signals.
+        cmd.process_group(0);
+    }
+
+    let child = cmd.spawn().context("spawning background gateway")?;
+    let pid = child.id();
+    std::fs::write(pid_path(), pid.to_string())
+        .with_context(|| format!("writing {}", pid_path().display()))?;
+
+    println!("nemesis8 gateway started in background (pid {pid}, port {port})");
+    println!("  logs:   {}", log_path().display());
+    println!("  status: n8 serve --status");
+    println!("  stop:   n8 serve --stop");
+    Ok(())
+}
+
+/// Report whether the gateway is running, using the PID file plus a /health
+/// probe so we catch stale PID files (process gone but file left behind).
+pub async fn status(port: u16) -> Result<()> {
+    let pid = read_pid();
+    let url = format!("http://127.0.0.1:{port}/health");
+    let healthy = match reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+    {
+        Ok(r) => r.status().is_success(),
+        Err(_) => false,
+    };
+
+    match (pid, healthy) {
+        (Some(p), true) => println!("running  (pid {p}, port {port})"),
+        (Some(p), false) => println!(
+            "not responding (pid {p} recorded but /health failed on port {port}) — try `n8 serve --stop` then `--background`"
+        ),
+        (None, true) => println!("running (port {port}, no pid file — started without --background)"),
+        (None, false) => println!("not running"),
+    }
+    Ok(())
+}
+
+/// Stop the background gateway by its recorded PID.
+pub fn stop() -> Result<()> {
+    let Some(pid) = read_pid() else {
+        println!("no pid file at {}; nothing to stop", pid_path().display());
+        return Ok(());
+    };
+
+    #[cfg(windows)]
+    let ok = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F", "/T"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    #[cfg(unix)]
+    let ok = std::process::Command::new("kill")
+        .arg(pid.to_string())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    let _ = std::fs::remove_file(pid_path());
+    if ok {
+        println!("stopped gateway (pid {pid})");
+    } else {
+        println!("pid {pid} was already gone; removed stale pid file");
+    }
+    Ok(())
+}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -866,6 +866,9 @@ impl DockerOps {
         if let Some(token) = auth_token {
             env.push(format!("NEMESIS8_AUTH_TOKEN={token}"));
         }
+        // Agent id == container name == the agent_id label, so the entry
+        // binary self-registers under the same id the registry discovers.
+        env.push(format!("NEMESIS8_AGENT_ID={container_name}"));
 
         let mut cmd = vec!["nemisis8-entry".to_string()];
         cmd.push("--prompt".to_string());

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -17,6 +17,31 @@ use crate::ui::{self, BuildEvent};
 const DEFAULT_IMAGE: &str = "nemisis8:latest";
 const DEFAULT_NETWORK: &str = "gnosis-network";
 
+/// Docker label keys applied to every nemesis8 agent container so the control
+/// plane can discover and address agents regardless of container name. The
+/// interactive path historically produced random Docker names (tender_agnesi,
+/// etc.) that name-substring matching couldn't track — labels fix that.
+pub const LABEL_AGENT: &str = "nemesis8.agent";
+pub const LABEL_AGENT_ID: &str = "nemesis8.agent_id";
+pub const LABEL_HOST_ID: &str = "nemesis8.host_id";
+pub const LABEL_PROVIDER: &str = "nemesis8.provider";
+
+/// Stable-ish host identifier (hostname). Used in agent labels and, later, the
+/// fleet registry's `{host_id}/{local_id}` agent IDs.
+pub fn host_id() -> String {
+    whoami::fallible::hostname().unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Build the standard agent label set for a container.
+fn agent_labels(provider: &str, agent_id: &str) -> std::collections::HashMap<String, String> {
+    let mut m = std::collections::HashMap::new();
+    m.insert(LABEL_AGENT.to_string(), "true".to_string());
+    m.insert(LABEL_AGENT_ID.to_string(), agent_id.to_string());
+    m.insert(LABEL_HOST_ID.to_string(), host_id());
+    m.insert(LABEL_PROVIDER.to_string(), provider.to_string());
+    m
+}
+
 /// Convert a Windows path to Docker-compatible format.
 /// `C:\Users\foo\bar` → `/c/Users/foo/bar`
 /// Non-Windows paths pass through unchanged.
@@ -310,8 +335,19 @@ impl DockerOps {
             .context("listing containers")?;
 
         let containers: Vec<_> = all.into_iter().filter(|c| {
+            // Preferred: the agent label (reliable, name-independent).
+            let has_label = c
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(LABEL_AGENT))
+                .map(|v| v == "true")
+                .unwrap_or(false);
+            if has_label {
+                return true;
+            }
+            // Fallback: legacy image/name/command matching so containers
+            // started by older (unlabeled) binaries are still discovered.
             let img = c.image.as_deref().unwrap_or("");
-            // Match current image, old image IDs (hex), or name patterns
             img.contains("nemisis8") || img.contains("nemesis8")
                 || c.names.as_ref().is_some_and(|names|
                     names.iter().any(|n| n.contains("nemisis8") || n.contains("nemesis8")))
@@ -703,6 +739,7 @@ impl DockerOps {
             cmd: Some(cmd),
             env: Some(env),
             host_config: Some(host_config),
+            labels: Some(agent_labels(&config.provider.to_string(), &container_name)),
             attach_stdout: Some(true),
             attach_stderr: Some(true),
             ..Default::default()
@@ -844,6 +881,7 @@ impl DockerOps {
             cmd: Some(cmd),
             env: Some(env),
             host_config: Some(host_config),
+            labels: Some(agent_labels(&config.provider.to_string(), &container_name)),
             tty: Some(true),
             attach_stdout: Some(true),
             attach_stderr: Some(true),
@@ -1296,6 +1334,21 @@ pub fn build_run_it_args(
         // affordance moves.
         "--detach-keys=ctrl-^".to_string(),
     ];
+
+    // Give the interactive container a deterministic name + agent labels so
+    // the control plane can discover it. Previously this path set no --name,
+    // so Docker assigned random names (tender_agnesi, romantic_hugle) that
+    // name-substring matching couldn't track.
+    let agent_id = format!("nemisis8-it-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+    let provider = env
+        .iter()
+        .find_map(|e| e.strip_prefix("NEMISIS8_PROVIDER="))
+        .unwrap_or("unknown");
+    args.push(format!("--name={agent_id}"));
+    args.push(format!("--label={LABEL_AGENT}=true"));
+    args.push(format!("--label={LABEL_AGENT_ID}={agent_id}"));
+    args.push(format!("--label={LABEL_HOST_ID}={}", host_id()));
+    args.push(format!("--label={LABEL_PROVIDER}={provider}"));
 
     // Match host's hostname and username so Gemini's FileKeychain
     // can decrypt OAuth tokens (encryption key = scrypt(hostname + username))

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -148,9 +148,49 @@ fn main() {
     // Resolve API key (generic)
     resolve_api_key_generic(&def);
 
+    // Register with the control plane if this container was spawned by a
+    // gateway (GATEWAY_URL + NEMESIS8_AGENT_ID present). Best-effort.
+    register_with_gateway(&def);
+
     // Launch the configured CLI (generic)
     let status = run_provider(&def, prompt.as_deref(), interactive, danger);
+
+    // Tell the control plane we're exiting (best-effort).
+    deregister_from_gateway();
+
     std::process::exit(status);
+}
+
+/// POST /agents/{id}/register to the gateway, if this container knows its
+/// gateway + agent id. Best-effort — failures are logged and ignored.
+fn register_with_gateway(def: &ProviderDef) {
+    let (gw, agent_id) = match (std::env::var("GATEWAY_URL"), std::env::var("NEMESIS8_AGENT_ID")) {
+        (Ok(g), Ok(a)) if !g.is_empty() && !a.is_empty() => (g, a),
+        _ => return,
+    };
+    let url = format!("{}/agents/{}/register", gw.trim_end_matches('/'), agent_id);
+    let token = std::env::var("NEMESIS8_AUTH_TOKEN").ok();
+    let body = serde_json::json!({
+        "provider": def.provider.name,
+        "workspace": workspace_root(),
+        "pid": std::process::id(),
+    })
+    .to_string();
+    match nemisis8::monitor::http_post_json(&url, &body, token.as_deref()) {
+        Ok(()) => eprintln!("[nemesis8-entry] registered with control plane ({agent_id})"),
+        Err(e) => eprintln!("[nemesis8-entry] register failed (non-fatal): {e}"),
+    }
+}
+
+/// POST /agents/{id}/deregister on exit. Best-effort.
+fn deregister_from_gateway() {
+    let (gw, agent_id) = match (std::env::var("GATEWAY_URL"), std::env::var("NEMESIS8_AGENT_ID")) {
+        (Ok(g), Ok(a)) if !g.is_empty() && !a.is_empty() => (g, a),
+        _ => return,
+    };
+    let url = format!("{}/agents/{}/deregister", gw.trim_end_matches('/'), agent_id);
+    let token = std::env::var("NEMESIS8_AUTH_TOKEN").ok();
+    let _ = nemisis8::monitor::http_post_json(&url, "{}", token.as_deref());
 }
 
 // ── Shared utility functions ────────────────────────────────────────────

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -31,6 +31,12 @@ pub struct GatewayConfig {
     pub trigger_store_path: String,
     pub scheduler_interval_secs: u64,
     pub timeout_secs: u64,
+    /// "controller" (default) or "worker".
+    pub role: String,
+    /// For workers: the controller base URL to register up to.
+    pub controller_url: Option<String>,
+    /// Stable host id; defaults to hostname when empty.
+    pub host_id: Option<String>,
 }
 
 impl Default for GatewayConfig {
@@ -54,6 +60,9 @@ impl Default for GatewayConfig {
             trigger_store_path: trigger_path,
             scheduler_interval_secs: 30,
             timeout_secs: 120,
+            role: "controller".to_string(),
+            controller_url: None,
+            host_id: None,
         }
     }
 }
@@ -79,6 +88,10 @@ struct AppState {
     registry_path: std::path::PathBuf,
     /// This daemon's host id (hostname); agent ids are `{host_id}/{local_id}`.
     host_id: String,
+    /// "controller" or "worker".
+    role: String,
+    /// For workers: controller base URL to register up to.
+    controller_url: Option<String>,
 }
 
 // ── Request / Response types ──
@@ -641,6 +654,8 @@ async fn kill_agent(
 ) -> Result<Json<AgentRecord>, (StatusCode, Json<ErrorResponse>)> {
     let gid;
     let container_ref;
+    let owner_host;
+    let local_id;
     {
         let reg = state.registry.lock().await;
         gid = resolve_agent_id(&reg, &state.host_id, &id);
@@ -649,6 +664,28 @@ async fn kill_agent(
             Json(ErrorResponse { error: format!("no agent '{id}'") }),
         ))?;
         container_ref = rec.container_id.clone().or_else(|| rec.container_name.clone());
+        owner_host = rec.host_id.clone();
+        local_id = rec.local_id.clone();
+    }
+
+    // If the agent lives on another host, route the kill to its daemon.
+    if owner_host != state.host_id {
+        let daemon_url = {
+            let reg = state.registry.lock().await;
+            reg.daemon_for_host(&owner_host).map(|d| d.url.clone())
+        };
+        let Some(url) = daemon_url else {
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse { error: format!("no daemon registered for host '{owner_host}'") }),
+            ));
+        };
+        let client = crate::remote::RemoteClient::new(&url, state.auth_token.as_deref());
+        return client
+            .kill_agent(&local_id)
+            .await
+            .map(Json)
+            .map_err(|e| (StatusCode::BAD_GATEWAY, Json(ErrorResponse { error: e.to_string() })));
     }
 
     if let Some(cref) = container_ref {
@@ -757,6 +794,56 @@ async fn spawn_agent(
     }))
 }
 
+#[derive(Deserialize)]
+struct DaemonRegisterRequest {
+    host_id: String,
+    url: String,
+    #[serde(default)]
+    role: String,
+}
+
+#[derive(Deserialize)]
+struct AgentsSyncRequest {
+    host_id: String,
+    agents: Vec<AgentRecord>,
+}
+
+/// POST /daemons/register — a worker registers itself with the controller.
+async fn register_daemon(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<DaemonRegisterRequest>,
+) -> Json<crate::registry::DaemonRecord> {
+    let rec = crate::registry::DaemonRecord {
+        host_id: req.host_id,
+        url: req.url,
+        role: if req.role.is_empty() { "worker".into() } else { req.role },
+        last_seen: chrono::Utc::now(),
+        agent_count: 0,
+    };
+    let mut reg = state.registry.lock().await;
+    reg.upsert_daemon(rec.clone());
+    let _ = reg.save(&state.registry_path);
+    Json(rec)
+}
+
+/// GET /daemons — list known worker daemons (controller view).
+async fn list_daemons(State(state): State<Arc<AppState>>) -> Json<Vec<crate::registry::DaemonRecord>> {
+    let reg = state.registry.lock().await;
+    Json(reg.daemons.clone())
+}
+
+/// POST /agents/sync — a worker pushes its full local agent snapshot up.
+/// The controller replaces all records for that host with the snapshot.
+async fn sync_agents(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<AgentsSyncRequest>,
+) -> StatusCode {
+    let mut reg = state.registry.lock().await;
+    reg.replace_host_agents(&req.host_id, req.agents);
+    let _ = reg.save(&state.registry_path);
+    StatusCode::NO_CONTENT
+}
+
 /// Resolve a user-supplied id (local_id, global id, or prefix) to a global id.
 fn resolve_agent_id(reg: &Registry, host_id: &str, id: &str) -> String {
     // Exact global id?
@@ -800,6 +887,56 @@ async fn reconcile_loop(state: Arc<AppState>, interval_secs: u64) {
     }
 }
 
+/// Worker daemon loop: register with the controller, then push the local
+/// agent snapshot up every 15s. Re-registers if a sync fails (controller may
+/// have restarted).
+async fn worker_sync_loop(state: Arc<AppState>, controller_url: String, own_url: String) {
+    let client = reqwest::Client::new();
+    let base = controller_url.trim_end_matches('/').to_string();
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
+    let mut registered = false;
+
+    loop {
+        interval.tick().await;
+
+        if !registered {
+            let body = serde_json::json!({
+                "host_id": &state.host_id, "url": &own_url, "role": "worker"
+            });
+            let mut req = client.post(format!("{base}/daemons/register")).json(&body);
+            if let Some(t) = &state.auth_token {
+                req = req.bearer_auth(t);
+            }
+            match req.send().await {
+                Ok(r) if r.status().is_success() => {
+                    registered = true;
+                    tracing::info!(controller = %base, "worker registered with controller");
+                }
+                Ok(r) => tracing::warn!("worker register got {}", r.status()),
+                Err(e) => tracing::warn!("worker register failed: {e}"),
+            }
+        }
+
+        let agents: Vec<AgentRecord> = {
+            let reg = state.registry.lock().await;
+            reg.agents
+                .iter()
+                .filter(|a| a.host_id == state.host_id)
+                .cloned()
+                .collect()
+        };
+        let body = serde_json::json!({ "host_id": &state.host_id, "agents": agents });
+        let mut req = client.post(format!("{base}/agents/sync")).json(&body);
+        if let Some(t) = &state.auth_token {
+            req = req.bearer_auth(t);
+        }
+        if let Err(e) = req.send().await {
+            registered = false;
+            tracing::warn!("worker sync failed: {e}");
+        }
+    }
+}
+
 /// Start the HTTP gateway with integrated scheduler
 pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
     let docker = DockerOps::new(Some(&gw_config.image))?;
@@ -821,7 +958,14 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("agents.json");
     let registry = Registry::load(&registry_path).unwrap_or_default();
-    let host_id = crate::docker::host_id();
+    let host_id = gw_config
+        .host_id
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(crate::docker::host_id);
+    let role = gw_config.role.clone();
+    let controller_url = gw_config.controller_url.clone();
+    let port = gw_config.port;
 
     let state = Arc::new(AppState {
         docker,
@@ -840,7 +984,9 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
         auth_token,
         registry: Mutex::new(registry),
         registry_path,
-        host_id,
+        host_id: host_id.clone(),
+        role: role.clone(),
+        controller_url: controller_url.clone(),
     });
 
     let app = Router::new()
@@ -854,10 +1000,13 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
         .route("/monitor/events", get(monitor_events))
         .route("/agents", get(list_agents))
         .route("/agents/spawn", post(spawn_agent))
+        .route("/agents/sync", post(sync_agents))
         .route("/agents/{id}", get(get_agent))
         .route("/agents/{id}/kill", post(kill_agent))
         .route("/agents/{id}/register", post(register_agent))
         .route("/agents/{id}/deregister", post(deregister_agent))
+        .route("/daemons", get(list_daemons))
+        .route("/daemons/register", post(register_daemon))
         .layer(middleware::from_fn(auth_middleware))
         .with_state(state.clone());
 
@@ -873,6 +1022,24 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
     tokio::spawn(async move {
         reconcile_loop(reconcile_state, 10).await;
     });
+
+    // If this daemon is a worker, register up to the controller and push the
+    // local agent snapshot on a heartbeat.
+    if state.role == "worker" {
+        match state.controller_url.clone() {
+            Some(curl) => {
+                let own_url = format!("http://{host_id}:{port}");
+                let worker_state = state.clone();
+                tracing::info!(controller = %curl, own = %own_url, "starting as worker daemon");
+                tokio::spawn(async move {
+                    worker_sync_loop(worker_state, curl, own_url).await;
+                });
+            }
+            None => {
+                tracing::warn!("control_plane.role=worker but no controller_url set; running standalone");
+            }
+        }
+    }
 
     let addr = format!("{}:{}", gw_config.bind, gw_config.port);
     tracing::info!(
@@ -935,6 +1102,8 @@ mod tests {
             registry: Mutex::new(Registry::default()),
             registry_path,
             host_id: "testhost".to_string(),
+            role: "controller".to_string(),
+            controller_url: None,
         })
     }
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -13,6 +13,7 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::config::Config;
 use crate::docker::DockerOps;
+use crate::registry::{AgentRecord, AgentState, Registry};
 use crate::scheduler::{Schedule, TriggerRecord, TriggerStore};
 use crate::session::{self, SessionInfo};
 
@@ -73,6 +74,11 @@ struct AppState {
     start_time: std::time::Instant,
     gateway_url: String,
     auth_token: Option<String>,
+    /// Agent registry (control plane). Persisted to `registry_path`.
+    registry: Mutex<Registry>,
+    registry_path: std::path::PathBuf,
+    /// This daemon's host id (hostname); agent ids are `{host_id}/{local_id}`.
+    host_id: String,
 }
 
 // ── Request / Response types ──
@@ -583,6 +589,217 @@ async fn monitor_events(
     Ok(Json(events))
 }
 
+// ── Agent registry handlers ──
+
+#[derive(Deserialize)]
+struct SpawnAgentRequest {
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    provider: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SpawnAck {
+    status: String,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct RegisterAgentRequest {
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    workspace: Option<String>,
+    #[serde(default)]
+    container_id: Option<String>,
+    #[serde(default)]
+    pid: Option<u32>,
+}
+
+/// GET /agents — current registry snapshot (refreshed by the reconcile loop).
+async fn list_agents(State(state): State<Arc<AppState>>) -> Json<Vec<AgentRecord>> {
+    let reg = state.registry.lock().await;
+    Json(reg.agents.clone())
+}
+
+/// GET /agents/{id} — one agent record. `{id}` is the local_id; we resolve it
+/// to this host's `{host_id}/{local_id}` global id.
+async fn get_agent(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<AgentRecord>, StatusCode> {
+    let reg = state.registry.lock().await;
+    let gid = resolve_agent_id(&reg, &state.host_id, &id);
+    reg.get(&gid).cloned().map(Json).ok_or(StatusCode::NOT_FOUND)
+}
+
+/// POST /agents/{id}/kill — stop the agent's container, mark Killed.
+async fn kill_agent(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<AgentRecord>, (StatusCode, Json<ErrorResponse>)> {
+    let gid;
+    let container_ref;
+    {
+        let reg = state.registry.lock().await;
+        gid = resolve_agent_id(&reg, &state.host_id, &id);
+        let rec = reg.get(&gid).ok_or((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse { error: format!("no agent '{id}'") }),
+        ))?;
+        container_ref = rec.container_id.clone().or_else(|| rec.container_name.clone());
+    }
+
+    if let Some(cref) = container_ref {
+        let _ = state.docker.stop_container(&cref).await;
+    }
+
+    let mut reg = state.registry.lock().await;
+    reg.mark_state(&gid, AgentState::Killed);
+    let rec = reg.get(&gid).cloned();
+    let _ = reg.save(&state.registry_path);
+    rec.map(Json).ok_or((
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse { error: format!("no agent '{id}'") }),
+    ))
+}
+
+/// POST /agents/{id}/register — container self-registers on boot.
+async fn register_agent(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<RegisterAgentRequest>,
+) -> Json<AgentRecord> {
+    let gid = AgentRecord::global_id(&state.host_id, &id);
+    let now = chrono::Utc::now();
+    let mut reg = state.registry.lock().await;
+    let existing = reg.get(&gid).cloned();
+    let record = AgentRecord {
+        id: gid.clone(),
+        host_id: state.host_id.clone(),
+        local_id: id.clone(),
+        provider: req.provider.or_else(|| existing.as_ref().and_then(|e| e.provider.clone())),
+        workspace: req.workspace.or_else(|| existing.as_ref().and_then(|e| e.workspace.clone())),
+        container_id: req.container_id.or_else(|| existing.as_ref().and_then(|e| e.container_id.clone())),
+        container_name: existing.as_ref().and_then(|e| e.container_name.clone()),
+        state: AgentState::Running,
+        source: crate::registry::AgentSource::Registered,
+        started_at: existing.as_ref().and_then(|e| e.started_at).or(Some(now)),
+        last_seen: Some(now),
+        last_prompt: existing.as_ref().and_then(|e| e.last_prompt.clone()),
+    };
+    reg.upsert(record.clone());
+    let _ = reg.save(&state.registry_path);
+    let _ = req.pid; // pid currently informational
+    Json(record)
+}
+
+/// POST /agents/{id}/deregister — container exiting.
+async fn deregister_agent(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> StatusCode {
+    let gid = AgentRecord::global_id(&state.host_id, &id);
+    let mut reg = state.registry.lock().await;
+    reg.mark_state(&gid, AgentState::Exited);
+    let _ = reg.save(&state.registry_path);
+    StatusCode::NO_CONTENT
+}
+
+/// POST /agents/spawn — launch a new agent by re-invoking the n8 binary
+/// detached (`n8 run <prompt>`). The spawned container is labeled, so the
+/// reconcile loop discovers it within one tick and it appears in /agents.
+/// This avoids cloning Config/DockerOps into a background task and reuses the
+/// exact same launch path as a manual `n8 run`.
+async fn spawn_agent(
+    State(_state): State<Arc<AppState>>,
+    Json(req): Json<SpawnAgentRequest>,
+) -> Result<Json<SpawnAck>, (StatusCode, Json<ErrorResponse>)> {
+    let prompt = req.prompt.unwrap_or_default();
+    if prompt.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse { error: "prompt is required".into() }),
+        ));
+    }
+    let exe = std::env::current_exe().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse { error: e.to_string() }))
+    })?;
+
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("run").arg(&prompt);
+    if let Some(p) = req.provider {
+        cmd.arg("--provider").arg(p);
+    }
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0000_0008 | 0x0000_0200);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
+    cmd.spawn().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse { error: format!("spawn failed: {e}") }))
+    })?;
+
+    Ok(Json(SpawnAck {
+        status: "spawning".into(),
+        message: "agent launching; it will appear in /agents within one reconcile tick (~10s)".into(),
+    }))
+}
+
+/// Resolve a user-supplied id (local_id, global id, or prefix) to a global id.
+fn resolve_agent_id(reg: &Registry, host_id: &str, id: &str) -> String {
+    // Exact global id?
+    if reg.agents.iter().any(|a| a.id == id) {
+        return id.to_string();
+    }
+    // host_id/local_id form for this host?
+    let gid = AgentRecord::global_id(host_id, id);
+    if reg.agents.iter().any(|a| a.id == gid) {
+        return gid;
+    }
+    // Prefix match on local_id (e.g. short id).
+    if let Some(a) = reg
+        .agents
+        .iter()
+        .find(|a| a.local_id.starts_with(id) || a.id.ends_with(id))
+    {
+        return a.id.clone();
+    }
+    gid
+}
+
+/// Background loop: reconcile the registry against live containers so agents
+/// started outside the API are discovered and dead ones are marked Exited.
+async fn reconcile_loop(state: Arc<AppState>, interval_secs: u64) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+    loop {
+        interval.tick().await;
+        let containers = match state.docker.list_containers("").await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("reconcile: list_containers failed: {e}");
+                continue;
+            }
+        };
+        let mut reg = state.registry.lock().await;
+        reg.reconcile(&containers, &state.host_id);
+        if let Err(e) = reg.save(&state.registry_path) {
+            tracing::warn!("reconcile: save failed: {e}");
+        }
+    }
+}
+
 /// Start the HTTP gateway with integrated scheduler
 pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
     let docker = DockerOps::new(Some(&gw_config.image))?;
@@ -597,6 +814,14 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
 
     let gateway_url = format!("http://host.docker.internal:{}", gw_config.port);
     let auth_token = std::env::var("NEMESIS8_AUTH_TOKEN").ok();
+
+    // Agent registry persisted next to the trigger store.
+    let registry_path = trigger_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("agents.json");
+    let registry = Registry::load(&registry_path).unwrap_or_default();
+    let host_id = crate::docker::host_id();
 
     let state = Arc::new(AppState {
         docker,
@@ -613,6 +838,9 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
         start_time: std::time::Instant::now(),
         gateway_url,
         auth_token,
+        registry: Mutex::new(registry),
+        registry_path,
+        host_id,
     });
 
     let app = Router::new()
@@ -624,6 +852,12 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
         .route("/triggers", get(list_triggers).post(create_trigger))
         .route("/triggers/{id}", get(get_trigger).put(update_trigger).delete(delete_trigger))
         .route("/monitor/events", get(monitor_events))
+        .route("/agents", get(list_agents))
+        .route("/agents/spawn", post(spawn_agent))
+        .route("/agents/{id}", get(get_agent))
+        .route("/agents/{id}/kill", post(kill_agent))
+        .route("/agents/{id}/register", post(register_agent))
+        .route("/agents/{id}/deregister", post(deregister_agent))
         .layer(middleware::from_fn(auth_middleware))
         .with_state(state.clone());
 
@@ -631,6 +865,13 @@ pub async fn serve(gw_config: GatewayConfig) -> Result<()> {
     let sched_state = state.clone();
     tokio::spawn(async move {
         scheduler_loop(sched_state, scheduler_interval).await;
+    });
+
+    // Spawn the registry reconciliation loop (discovers agents started outside
+    // the API, marks dead ones Exited). 10s cadence.
+    let reconcile_state = state.clone();
+    tokio::spawn(async move {
+        reconcile_loop(reconcile_state, 10).await;
     });
 
     let addr = format!("{}:{}", gw_config.bind, gw_config.port);
@@ -672,6 +913,7 @@ mod tests {
         let docker = DockerOps::new(None).unwrap();
         let dir = tempfile::tempdir().unwrap();
         let trigger_path = dir.path().join("triggers.json");
+        let registry_path = dir.path().join("agents.json");
         // Leak the tempdir so it lives for the test
         std::mem::forget(dir);
 
@@ -690,6 +932,9 @@ mod tests {
             start_time: std::time::Instant::now(),
             gateway_url: "http://host.docker.internal:4000".to_string(),
             auth_token: None,
+            registry: Mutex::new(Registry::default()),
+            registry_path,
+            host_id: "testhost".to_string(),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod monitor;
 pub mod pokeball;
 pub mod provider_def;
 pub mod provider_registry;
+pub mod registry;
 pub mod remote;
 pub mod scheduler;
 pub mod session;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod config;
+pub mod daemon;
 pub mod docker;
 pub mod gateway;
 pub mod monitor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,21 @@ async fn main() -> Result<()> {
             }
         }
 
-        Command::Serve => {
+        Command::Serve { background, status, stop } => {
+            // Daemon control paths short-circuit before touching Docker.
+            if stop {
+                nemisis8::daemon::stop()?;
+                return Ok(());
+            }
+            if status {
+                nemisis8::daemon::status(cli.port).await?;
+                return Ok(());
+            }
+            if background {
+                nemisis8::daemon::spawn_background(cli.port)?;
+                return Ok(());
+            }
+
             // Check if gateway is already running on this port
             let check_url = format!("http://127.0.0.1:{}/health", cli.port);
             if let Ok(resp) = reqwest::get(&check_url).await {
@@ -567,7 +581,7 @@ async fn run_remote(
             std::process::exit(1);
         }
 
-        Command::Serve => {
+        Command::Serve { .. } => {
             eprintln!("Error: 'serve' IS the gateway server. It cannot delegate to a remote.");
             eprintln!("Remove --remote / NEMESIS8_REMOTE to start the server locally.");
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,17 @@ async fn main() -> Result<()> {
     // Resolve remote URL: CLI flag > config file
     let remote_url = cli.remote.as_deref().or(config.remote.as_deref());
 
+    // Fleet control is a pure gateway client — it talks HTTP to a gateway
+    // (remote if set, else the local one on --port) and never needs Docker.
+    if let Command::Agents { action } = &cli.command {
+        let gw = remote_url
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("http://localhost:{}", cli.port));
+        let token = cli.token.as_deref().or(config.remote_token.as_deref());
+        let client = nemisis8::remote::RemoteClient::new(&gw, token);
+        return handle_agents(action.as_ref(), &client).await;
+    }
+
     if let Some(url) = remote_url {
         let token = cli.token.as_deref().or(config.remote_token.as_deref());
         let client = nemisis8::remote::RemoteClient::new(url, token);
@@ -298,6 +309,14 @@ async fn main() -> Result<()> {
             }
             ensure_image(&docker, &config).await?;
             drop(docker); // Gateway creates its own Docker connection
+            let (role, controller_url, host_id) = match &config.control_plane {
+                Some(cp) => (
+                    cp.role.clone(),
+                    cp.controller_url.clone(),
+                    cp.host_id.clone(),
+                ),
+                None => ("controller".to_string(), None, None),
+            };
             let gw_config = GatewayConfig {
                 port: cli.port,
                 config,
@@ -305,6 +324,9 @@ async fn main() -> Result<()> {
                 danger: cli.danger,
                 model: cli.model.clone(),
                 image: cli.tag.clone().unwrap_or_else(|| "nemisis8:latest".to_string()),
+                role,
+                controller_url,
+                host_id,
                 ..Default::default()
             };
             gateway::serve(gw_config).await?;
@@ -377,7 +399,7 @@ async fn main() -> Result<()> {
         }
 
         // Handled above before Docker connect — all return early, never reach here
-        Command::Sessions { .. } | Command::Init | Command::Doctor | Command::Mount { .. } | Command::Mcp { .. } | Command::Update => unreachable!(),
+        Command::Sessions { .. } | Command::Init | Command::Doctor | Command::Mount { .. } | Command::Mcp { .. } | Command::Update | Command::Agents { .. } => unreachable!(),
 
         Command::Ps => {
             let image = docker.image_name();
@@ -727,6 +749,48 @@ async fn ensure_image(docker: &DockerOps, config: &Config) -> Result<()> {
     docker.build(&project_dir(), config.docker_build_args()).await?;
 
     eprintln!("Image built successfully.");
+    Ok(())
+}
+
+/// Handle `n8 agents` — fleet control via the gateway HTTP API.
+async fn handle_agents(
+    action: Option<&nemisis8::cli::AgentsAction>,
+    client: &nemisis8::remote::RemoteClient,
+) -> Result<()> {
+    use nemisis8::cli::AgentsAction;
+    match action {
+        None | Some(AgentsAction::List) => {
+            let agents = client.list_agents().await?;
+            if agents.is_empty() {
+                println!("No agents.");
+                return Ok(());
+            }
+            println!(
+                "{:<30}  {:<11}  {:<10}  {:<11}  {}",
+                "ID", "PROVIDER", "STATE", "SOURCE", "WORKSPACE"
+            );
+            println!("{}", "-".repeat(90));
+            for a in &agents {
+                println!(
+                    "{:<30}  {:<11}  {:<10}  {:<11}  {}",
+                    a.id,
+                    a.provider.as_deref().unwrap_or("-"),
+                    format!("{:?}", a.state).to_lowercase(),
+                    format!("{:?}", a.source).to_lowercase(),
+                    a.workspace.as_deref().unwrap_or("")
+                );
+            }
+            println!("  ({} agents)", agents.len());
+        }
+        Some(AgentsAction::Kill { id }) => {
+            let rec = client.kill_agent(id).await?;
+            println!("killed {} (state now {:?})", rec.id, rec.state);
+        }
+        Some(AgentsAction::Spawn { prompt }) => {
+            let resp = client.spawn_agent(prompt, None).await?;
+            println!("{}", serde_json::to_string_pretty(&resp)?);
+        }
+    }
     Ok(())
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -98,6 +98,76 @@ impl EventSink for JsonlSink {
     }
 }
 
+/// Minimal fire-and-forget HTTP POST (plain HTTP, no TLS). Used by the
+/// monitor's HttpSink and the entry binary's register/deregister — both are
+/// synchronous and shouldn't drag in an async runtime just to POST JSON to
+/// the host gateway. Connects, writes, closes; the response is ignored.
+pub fn http_post_json(url: &str, body: &str, token: Option<&str>) -> std::io::Result<()> {
+    let rest = url.strip_prefix("http://").ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "only http:// supported")
+    })?;
+    let (hostport, path) = match rest.split_once('/') {
+        Some((h, p)) => (h.to_string(), format!("/{p}")),
+        None => (rest.to_string(), "/".to_string()),
+    };
+    let mut stream = std::net::TcpStream::connect(&hostport)?;
+    let auth = token
+        .map(|t| format!("Authorization: Bearer {t}\r\n"))
+        .unwrap_or_default();
+    let req = format!(
+        "POST {path} HTTP/1.1\r\nHost: {hostport}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{auth}Connection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(req.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
+/// EventSink that POSTs each event to a gateway URL (e.g.
+/// http://host.docker.internal:4000/agents/<id>/events). Best-effort:
+/// a failed POST is swallowed so a missing/unreachable gateway never breaks
+/// the monitor.
+pub struct HttpSink {
+    events_url: String,
+    token: Option<String>,
+}
+
+impl HttpSink {
+    pub fn new(events_url: String, token: Option<String>) -> Self {
+        Self { events_url, token }
+    }
+}
+
+impl EventSink for HttpSink {
+    fn write_event(&mut self, event: &MonitorEvent) -> Result<()> {
+        let body = serde_json::to_string(event)?;
+        // Swallow transport errors — telemetry is best-effort.
+        let _ = http_post_json(&self.events_url, &body, self.token.as_deref());
+        Ok(())
+    }
+}
+
+/// Fan-out sink: write each event to every contained sink. Lets the monitor
+/// keep a durable local JSONL record AND push to the gateway at once.
+pub struct TeeSink {
+    sinks: Vec<Box<dyn EventSink>>,
+}
+
+impl TeeSink {
+    pub fn new(sinks: Vec<Box<dyn EventSink>>) -> Self {
+        Self { sinks }
+    }
+}
+
+impl EventSink for TeeSink {
+    fn write_event(&mut self, event: &MonitorEvent) -> Result<()> {
+        for s in self.sinks.iter_mut() {
+            let _ = s.write_event(event);
+        }
+        Ok(())
+    }
+}
+
 pub fn now_ts() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src/monitor_main.rs
+++ b/src/monitor_main.rs
@@ -11,16 +11,31 @@
 
 use std::path::Path;
 
-use nemisis8::monitor::{run_monitor, JsonlSink, EVENTS_FILE};
+use nemisis8::monitor::{run_monitor, EventSink, HttpSink, JsonlSink, TeeSink, EVENTS_FILE};
 
 fn main() {
-    let mut sink = match JsonlSink::new(EVENTS_FILE) {
+    // Always keep a durable local JSONL record. If this container was spawned
+    // by a gateway (GATEWAY_URL + NEMESIS8_AGENT_ID present), ALSO push events
+    // up to /agents/<id>/events so the control plane gets live telemetry.
+    let jsonl = match JsonlSink::new(EVENTS_FILE) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("[nemesis8-monitor] could not open event sink: {e}");
             std::process::exit(1);
         }
     };
+
+    let mut sinks: Vec<Box<dyn EventSink>> = vec![Box::new(jsonl)];
+    if let (Ok(gw), Ok(agent_id)) = (
+        std::env::var("GATEWAY_URL"),
+        std::env::var("NEMESIS8_AGENT_ID"),
+    ) {
+        let url = format!("{}/agents/{}/events", gw.trim_end_matches('/'), agent_id);
+        let token = std::env::var("NEMESIS8_AUTH_TOKEN").ok();
+        eprintln!("[nemesis8-monitor] pushing telemetry to {url}");
+        sinks.push(Box::new(HttpSink::new(url, token)));
+    }
+    let mut sink = TeeSink::new(sinks);
 
     // Workspace is the only thing worth watching by default. /opt/nemesis8
     // would generate a torrent of self-noise from agy's brain dir.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,227 @@
+//! Agent registry — the control plane's record of which agents exist, their
+//! state, and which container backs them.
+//!
+//! Mirrors `scheduler::TriggerStore`: an in-memory `Vec` persisted to JSON
+//! under ~/.codex-service/agents.json. The key behavior beyond simple
+//! tracking is `reconcile()`, which folds the live `docker ps` view into the
+//! registry — so agents started outside the API (interactive `n8 run`, `agy`
+//! sessions, anything launched by hand) show up too, and agents whose
+//! container has vanished get marked Exited.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentState {
+    Starting,
+    Running,
+    Idle,
+    Exited,
+    Killed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentSource {
+    /// Spawned through the control-plane API.
+    Spawned,
+    /// Adopted from `docker ps` during reconciliation (started outside the API).
+    Discovered,
+    /// Self-registered by the container's entry binary on boot.
+    Registered,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRecord {
+    /// Global id: `{host_id}/{local_id}` so control routes to the owning daemon.
+    pub id: String,
+    pub host_id: String,
+    pub local_id: String,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub workspace: Option<String>,
+    #[serde(default)]
+    pub container_id: Option<String>,
+    #[serde(default)]
+    pub container_name: Option<String>,
+    pub state: AgentState,
+    pub source: AgentSource,
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub last_seen: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub last_prompt: Option<String>,
+}
+
+impl AgentRecord {
+    pub fn global_id(host_id: &str, local_id: &str) -> String {
+        format!("{host_id}/{local_id}")
+    }
+}
+
+/// Persistent agent registry (JSON file).
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Registry {
+    pub agents: Vec<AgentRecord>,
+}
+
+impl Registry {
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("reading registry from {}", path.display()))?;
+        serde_json::from_str(&content).with_context(|| "parsing registry JSON")
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, content)
+            .with_context(|| format!("writing registry to {}", path.display()))
+    }
+
+    pub fn get(&self, id: &str) -> Option<&AgentRecord> {
+        self.agents.iter().find(|a| a.id == id)
+    }
+
+    pub fn upsert(&mut self, record: AgentRecord) {
+        if let Some(existing) = self.agents.iter_mut().find(|a| a.id == record.id) {
+            *existing = record;
+        } else {
+            self.agents.push(record);
+        }
+    }
+
+    pub fn remove(&mut self, id: &str) -> bool {
+        let before = self.agents.len();
+        self.agents.retain(|a| a.id != id);
+        self.agents.len() < before
+    }
+
+    pub fn mark_state(&mut self, id: &str, state: AgentState) -> bool {
+        if let Some(a) = self.agents.iter_mut().find(|a| a.id == id) {
+            a.state = state;
+            a.last_seen = Some(Utc::now());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Fold the live container list (this host) into the registry.
+    /// - labeled/known containers present → state Running, refresh container id/name
+    /// - present container with no matching record → adopt as Discovered/Running
+    /// - record for this host whose container is gone → mark Exited
+    ///
+    /// `containers` is the filtered nemesis8 container list from
+    /// `DockerOps::list_containers`.
+    pub fn reconcile(
+        &mut self,
+        containers: &[bollard::models::ContainerSummary],
+        host_id: &str,
+    ) {
+        use crate::docker::{LABEL_AGENT_ID, LABEL_PROVIDER};
+
+        let mut present: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for c in containers {
+            let labels = c.labels.clone().unwrap_or_default();
+            let cname = c
+                .names
+                .as_ref()
+                .and_then(|n| n.first())
+                .map(|n| n.trim_start_matches('/').to_string());
+            // local_id preference: agent_id label > container name > short id
+            let local_id = labels
+                .get(LABEL_AGENT_ID)
+                .cloned()
+                .or_else(|| cname.clone())
+                .or_else(|| c.id.as_ref().map(|i| i.chars().take(12).collect()))
+                .unwrap_or_else(|| "unknown".to_string());
+            let gid = AgentRecord::global_id(host_id, &local_id);
+            present.insert(gid.clone());
+
+            let provider = labels.get(LABEL_PROVIDER).cloned();
+            let now = Utc::now();
+
+            if let Some(rec) = self.agents.iter_mut().find(|a| a.id == gid) {
+                rec.container_id = c.id.clone();
+                rec.container_name = cname;
+                rec.last_seen = Some(now);
+                if rec.state == AgentState::Exited || rec.state == AgentState::Killed {
+                    rec.state = AgentState::Running; // reappeared
+                }
+                if rec.provider.is_none() {
+                    rec.provider = provider;
+                }
+            } else {
+                self.agents.push(AgentRecord {
+                    id: gid,
+                    host_id: host_id.to_string(),
+                    local_id,
+                    provider,
+                    workspace: None,
+                    container_id: c.id.clone(),
+                    container_name: cname,
+                    state: AgentState::Running,
+                    source: AgentSource::Discovered,
+                    started_at: Some(now),
+                    last_seen: Some(now),
+                    last_prompt: None,
+                });
+            }
+        }
+
+        // Anything on this host that we thought was live but isn't present → Exited.
+        for rec in self.agents.iter_mut() {
+            if rec.host_id == host_id
+                && !present.contains(&rec.id)
+                && matches!(
+                    rec.state,
+                    AgentState::Running | AgentState::Starting | AgentState::Idle
+                )
+            {
+                rec.state = AgentState::Exited;
+                rec.last_seen = Some(Utc::now());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_and_get() {
+        let mut r = Registry::default();
+        r.upsert(AgentRecord {
+            id: "h/a".into(),
+            host_id: "h".into(),
+            local_id: "a".into(),
+            provider: Some("codex".into()),
+            workspace: None,
+            container_id: None,
+            container_name: None,
+            state: AgentState::Running,
+            source: AgentSource::Spawned,
+            started_at: None,
+            last_seen: None,
+            last_prompt: None,
+        });
+        assert!(r.get("h/a").is_some());
+        assert!(r.mark_state("h/a", AgentState::Killed));
+        assert_eq!(r.get("h/a").unwrap().state, AgentState::Killed);
+        assert!(r.remove("h/a"));
+        assert!(r.get("h/a").is_none());
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -64,10 +64,25 @@ impl AgentRecord {
     }
 }
 
+/// A worker daemon known to the controller.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonRecord {
+    pub host_id: String,
+    /// Base URL the controller uses to reach this daemon (e.g. http://server:4000).
+    pub url: String,
+    pub role: String,
+    pub last_seen: DateTime<Utc>,
+    #[serde(default)]
+    pub agent_count: usize,
+}
+
 /// Persistent agent registry (JSON file).
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Registry {
     pub agents: Vec<AgentRecord>,
+    /// Worker daemons that have registered up (controller side).
+    #[serde(default)]
+    pub daemons: Vec<DaemonRecord>,
 }
 
 impl Registry {
@@ -114,6 +129,34 @@ impl Registry {
             true
         } else {
             false
+        }
+    }
+
+    // ── Fleet (controller side) ──
+
+    /// Upsert a worker daemon registration.
+    pub fn upsert_daemon(&mut self, rec: DaemonRecord) {
+        if let Some(existing) = self.daemons.iter_mut().find(|d| d.host_id == rec.host_id) {
+            *existing = rec;
+        } else {
+            self.daemons.push(rec);
+        }
+    }
+
+    /// Find the daemon that owns a given host_id.
+    pub fn daemon_for_host(&self, host_id: &str) -> Option<&DaemonRecord> {
+        self.daemons.iter().find(|d| d.host_id == host_id)
+    }
+
+    /// Replace ALL agents belonging to a host with the supplied snapshot.
+    /// Used by /agents/sync so a worker's pushed view is authoritative for
+    /// its own host (exited agents simply drop out of subsequent snapshots).
+    pub fn replace_host_agents(&mut self, host_id: &str, mut agents: Vec<AgentRecord>) {
+        self.agents.retain(|a| a.host_id != host_id);
+        self.agents.append(&mut agents);
+        if let Some(d) = self.daemons.iter_mut().find(|d| d.host_id == host_id) {
+            d.agent_count = self.agents.iter().filter(|a| a.host_id == host_id).count();
+            d.last_seen = Utc::now();
         }
     }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -122,4 +122,27 @@ impl RemoteClient {
         let resp = self.send(req).await?;
         resp.json().await.context("parsing session response")
     }
+
+    /// GET /agents — the fleet's agent list (controller merges local + workers).
+    pub async fn list_agents(&self) -> Result<Vec<crate::registry::AgentRecord>> {
+        let req = self.request(reqwest::Method::GET, "/agents");
+        let resp = self.send(req).await?;
+        resp.json().await.context("parsing agents response")
+    }
+
+    /// POST /agents/{id}/kill — kill an agent (id may be local_id, global, or prefix).
+    pub async fn kill_agent(&self, id: &str) -> Result<crate::registry::AgentRecord> {
+        let path = format!("/agents/{id}/kill");
+        let req = self.request(reqwest::Method::POST, &path);
+        let resp = self.send(req).await?;
+        resp.json().await.context("parsing kill response")
+    }
+
+    /// POST /agents/spawn — launch a new agent on the gateway.
+    pub async fn spawn_agent(&self, prompt: &str, provider: Option<&str>) -> Result<serde_json::Value> {
+        let body = serde_json::json!({ "prompt": prompt, "provider": provider });
+        let req = self.request(reqwest::Method::POST, "/agents/spawn").json(&body);
+        let resp = self.send(req).await?;
+        resp.json().await.context("parsing spawn response")
+    }
 }


### PR DESCRIPTION
Turns the gateway into a control plane: a hierarchical daemon model with a controller-held shared registry, so every agent — interactive, scheduled, or spawned — registers and is visible/controllable from one place, across multiple hosts.

Plan: `~/.claude/plans/adaptive-yawning-newt.md` (controller-held registry, daemon mode, host-process controller).

## Milestones

**M1 — daemon mode** (`src/daemon.rs`)
`n8 serve --background` (detach + PID/log file), `--status`, `--stop`. Verified live.

**M2 — labels + registry + telemetry**
- Every container gets `nemesis8.agent/agent_id/host_id/provider` labels; interactive path gets a real `--name` (no more random `tender_agnesi`). `list_containers` matches by label.
- `src/registry.rs`: AgentRecord/Registry (JSON persist) + `reconcile()` that folds the live `docker ps` view in — agents started outside the API are **discovered**, dead ones marked Exited.
- Gateway routes: `GET /agents`, `GET /agents/{id}`, `POST /agents/spawn|{id}/kill|{id}/register|{id}/deregister`; 10s reconcile loop.
- entry self-registers on boot/exit; monitor tees telemetry to JSONL + gateway push (`/agents/{id}/events`).
- Verified live: with two unlabeled agy containers already running, `GET /agents` discovered both.

**M3 — hierarchy** (multi-host)
- `[control_plane]` config (role / controller_url / host_id).
- `POST /daemons/register`, `GET /daemons`, `POST /agents/sync`; workers register up + push snapshots every 15s; controller merges the fleet view; cross-host `kill` routes to the owning daemon.
- `n8 agents [list|kill|spawn]` CLI.
- Verified live (single-machine sim): fleet view showed local + worker-reported agents from two hosts in one list.

**M4 — orchestrator MCP**
`MCP/nemesis8-orchestrator.py` gains `agent_list/agent_get/agent_spawn/agent_kill/agent_events/daemon_list`.

## Still needs real-hardware verification
- **In-container entry registration + monitor push**: only runs inside a freshly built image (`n8 build`).
- **True two-box hierarchy**: controller on workstation + worker on the house server (config `role="worker"`, `controller_url=...`).

157 lib tests green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)