### PR TITLE
Event search on lume + tool_call feed — ranked full-history search, who-called-what events

### DIFF
--- a/prompts/BASE.md
+++ b/prompts/BASE.md
@@ -12,4 +12,6 @@ You are an autonomous coding agent running inside an n8 container. Re-read these
 
 6. **Own mistakes in place.** Acknowledge them, fix them with the approved tools, and keep going within the same workflow.
 
+7. **Bind servers to 0.0.0.0, not localhost.** You run inside a container: a server bound to 127.0.0.1 is unreachable from the host even when the port is published. Bind 0.0.0.0 (or ::) so published ports actually work.
+
 Confirm your plan respects these guardrails before taking action.

--- a/src/collectors.rs
+++ b/src/collectors.rs
@@ -257,6 +257,9 @@ pub struct LogTailer {
     offsets: HashMap<PathBuf, u64>,
     max_files: usize,
     max_line_bytes: usize,
+    /// Files that turned out to be binary wearing a .log extension — tailed
+    /// once, produced soup, never read again (one notice line is emitted).
+    binary_blacklist: std::collections::HashSet<PathBuf>,
 }
 
 impl LogTailer {
@@ -266,6 +269,7 @@ impl LogTailer {
             offsets: HashMap::new(),
             max_files: 128,
             max_line_bytes: 16 * 1024,
+            binary_blacklist: std::collections::HashSet::new(),
         }
     }
 
@@ -274,6 +278,9 @@ impl LogTailer {
     pub fn poll(&mut self) -> Vec<(String, String)> {
         let mut out = Vec::new();
         for f in discover_logs(&self.root, self.max_files) {
+            if self.binary_blacklist.contains(&f) {
+                continue;
+            }
             let Ok(meta) = fs::metadata(&f) else { continue };
             let size = meta.len();
             let start = match self.offsets.get(&f).copied() {
@@ -286,6 +293,12 @@ impl LogTailer {
             }
             if let Ok(chunk) = read_range(&f, start, size) {
                 let path = f.to_string_lossy().to_string();
+                if crate::event_store::looks_binary(&chunk) {
+                    self.binary_blacklist.insert(f.clone());
+                    self.offsets.insert(f, size);
+                    out.push((path, "[log tailer] binary-looking file skipped".to_string()));
+                    continue;
+                }
                 for line in chunk.lines() {
                     let line = truncate_chars(line, self.max_line_bytes);
                     if !line.is_empty() {

--- a/src/event_store.rs
+++ b/src/event_store.rs
@@ -1,0 +1,342 @@
+//! Lume-backed event search (#79) — ranked, full-history, on the vendored
+//! BM25 engine. This is the SEARCH half of the event pipeline; the in-memory
+//! ring (`event_index`) keeps the LIVE jobs it is good at (tail, SSE,
+//! sparklines, rollups). Query routing upstream: `q` present → THIS store;
+//! no `q` → the ring. One contract, two engines.
+//!
+//! Lume's `Bm25Index` is build-once, so the store is TWO-TIER:
+//!
+//!   docs[..base_len]  — covered by a built `Bm25Index` (ranked retrieval)
+//!   docs[base_len..]  — the DELTA tail, matched by linear token scan
+//!
+//! Ingest appends to the delta (cheap); when the delta outgrows
+//! `rebuild_threshold` the base is rebuilt over the whole corpus. Search
+//! results are the union (base hits ∪ delta matches) post-filtered by
+//! kind/agent/since, ordered newest-first — Splunk semantics: time-ordered
+//! matches, relevance decides membership, not order.
+//!
+//! `metric` and `heartbeat` events are NOT indexed — they are chart fodder
+//! (2/3 of the stream, no searchable text). Kind-filtered queries for them
+//! fall back to the ring upstream.
+
+use lume::bm25::{Bm25Index, Bm25Params, SearchVariant, Section};
+
+/// Kinds that never enter the search corpus.
+const EXCLUDED_KINDS: &[&str] = &["metric", "heartbeat"];
+/// Rebuild the base index when the delta tail exceeds this many docs.
+const DEFAULT_REBUILD_THRESHOLD: usize = 2_000;
+/// Hard corpus cap — beyond this the oldest half is dropped (the files
+/// themselves rotate at 2×32MB, so this is a backstop, not the retention
+/// policy).
+const MAX_DOCS: usize = 250_000;
+
+/// One searchable event.
+pub struct EventDoc {
+    pub ts: u64,
+    pub kind: String,
+    pub agent: Option<String>,
+    pub raw: serde_json::Value,
+    /// Flattened searchable text: kind, agent, and every top-level string
+    /// field of the event (path, msg, status, kind_detail, …).
+    pub text: String,
+}
+
+pub struct EventStore {
+    docs: Vec<EventDoc>,
+    base: Option<Bm25Index>,
+    base_len: usize,
+    pub rebuild_threshold: usize,
+}
+
+impl Default for EventStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventStore {
+    pub fn new() -> Self {
+        Self {
+            docs: Vec::new(),
+            base: None,
+            base_len: 0,
+            rebuild_threshold: DEFAULT_REBUILD_THRESHOLD,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.docs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.docs.is_empty()
+    }
+
+    /// Parse one JSONL line into the corpus. Excluded kinds and unparseable
+    /// lines are skipped. Triggers a base rebuild when the delta is due.
+    pub fn ingest_line(&mut self, line: &str) {
+        if self.push_line(line) {
+            self.maybe_rebuild();
+        }
+    }
+
+    /// Bulk-load a whole events file (startup): push everything, ONE rebuild
+    /// at the end — never O(n²).
+    pub fn ingest_file(&mut self, path: &std::path::Path) -> std::io::Result<usize> {
+        use std::io::BufRead;
+        let f = std::fs::File::open(path)?;
+        let reader = std::io::BufReader::new(f);
+        let mut added = 0usize;
+        for line in reader.lines() {
+            let Ok(line) = line else { continue };
+            if self.push_line(&line) {
+                added += 1;
+            }
+        }
+        self.rebuild_base();
+        Ok(added)
+    }
+
+    fn push_line(&mut self, line: &str) -> bool {
+        let line = line.trim();
+        if line.is_empty() {
+            return false;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            return false;
+        };
+        let kind = v
+            .get("kind")
+            .and_then(|k| k.as_str())
+            .unwrap_or("event")
+            .to_string();
+        if EXCLUDED_KINDS.contains(&kind.as_str()) {
+            return false;
+        }
+        let agent = v
+            .get("agent_id")
+            .and_then(|a| a.as_str())
+            .map(String::from);
+        let ts = v.get("ts").and_then(|t| t.as_u64()).unwrap_or(0);
+
+        // Searchable text: kind + agent + every top-level string value. No
+        // per-kind schema to rot — a new event kind is searchable on arrival.
+        let mut text = String::with_capacity(64);
+        text.push_str(&kind);
+        if let Some(a) = &agent {
+            text.push(' ');
+            text.push_str(a);
+        }
+        if let Some(obj) = v.as_object() {
+            for (k, val) in obj {
+                if k == "agent_id" || k == "kind" {
+                    continue;
+                }
+                if let Some(s) = val.as_str() {
+                    text.push(' ');
+                    text.push_str(s);
+                }
+            }
+        }
+
+        self.docs.push(EventDoc {
+            ts,
+            kind,
+            agent,
+            raw: v,
+            text,
+        });
+
+        if self.docs.len() > MAX_DOCS {
+            let drop = self.docs.len() / 2;
+            self.docs.drain(0..drop);
+            self.rebuild_base();
+        }
+        true
+    }
+
+    fn maybe_rebuild(&mut self) {
+        if self.docs.len().saturating_sub(self.base_len) >= self.rebuild_threshold {
+            self.rebuild_base();
+        }
+    }
+
+    fn rebuild_base(&mut self) {
+        let sections: Vec<Section> = self
+            .docs
+            .iter()
+            .enumerate()
+            .map(|(i, d)| Section {
+                title: match &d.agent {
+                    Some(a) => format!("{} {}", d.kind, a),
+                    None => d.kind.clone(),
+                },
+                body: d.text.clone(),
+                line_number: i,
+                filename: None,
+            })
+            .collect();
+        self.base = if sections.is_empty() {
+            None
+        } else {
+            Some(Bm25Index::build(sections, None))
+        };
+        self.base_len = self.docs.len();
+    }
+
+    /// Ranked-membership, time-ordered search. `q` decides WHICH docs match
+    /// (BM25 over the base + token scan over the delta); the result is then
+    /// filtered by kind/agent/since and returned NEWEST FIRST, truncated to
+    /// `limit`.
+    pub fn search(
+        &self,
+        q: &str,
+        kinds: &[String],
+        agent: Option<&str>,
+        since: Option<u64>,
+        limit: usize,
+    ) -> Vec<&EventDoc> {
+        let mut idxs: Vec<usize> = Vec::new();
+
+        // Base: BM25 hits map back to doc indices via Section.line_number.
+        if let Some(base) = &self.base {
+            let hits = base.search(q, SearchVariant::Classic, &Bm25Params::default(), None);
+            for h in hits {
+                if let Some(sec) = base.sections.get(h.section_index) {
+                    idxs.push(sec.line_number);
+                }
+            }
+        }
+
+        // Delta: every query token must appear (case-insensitive) in the text.
+        let tokens: Vec<String> = lume::tokenize(q)
+            .into_iter()
+            .map(|t| String::from_utf8_lossy(&t.bytes).to_lowercase())
+            .collect();
+        if !tokens.is_empty() {
+            for (i, d) in self.docs.iter().enumerate().skip(self.base_len) {
+                let hay = d.text.to_lowercase();
+                if tokens.iter().all(|t| hay.contains(t.as_str())) {
+                    idxs.push(i);
+                }
+            }
+        }
+
+        idxs.sort_unstable();
+        idxs.dedup();
+
+        let mut out: Vec<&EventDoc> = idxs
+            .into_iter()
+            .filter_map(|i| self.docs.get(i))
+            .filter(|d| kinds.is_empty() || kinds.contains(&d.kind))
+            .filter(|d| agent.is_none_or(|a| d.agent.as_deref() == Some(a)))
+            .filter(|d| since.is_none_or(|s| d.ts >= s))
+            .collect();
+        out.sort_by(|a, b| b.ts.cmp(&a.ts));
+        out.truncate(limit);
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(kind: &str, agent: &str, ts: u64, extra: &str) -> String {
+        format!(
+            r#"{{"kind":"{kind}","agent_id":"{agent}","ts":{ts},{extra}}}"#
+        )
+    }
+
+    fn store_with(lines: &[String]) -> EventStore {
+        let mut s = EventStore::new();
+        for l in lines {
+            s.ingest_line(l);
+        }
+        s
+    }
+
+    #[test]
+    fn metric_and_heartbeat_are_not_indexed() {
+        let s = store_with(&[
+            line("metric", "a1", 10, r#""cpu_pct":5"#),
+            line("heartbeat", "a1", 11, r#""pid":1"#),
+            line("fs", "a1", 12, r#""path":"/workspace/x.rs","kind_detail":"accessed""#),
+        ]);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s.docs[0].kind, "fs");
+    }
+
+    #[test]
+    fn delta_search_finds_paths_before_any_rebuild() {
+        let s = store_with(&[
+            line("fs", "a1", 10, r#""path":"/workspace/web/fleet.html","kind_detail":"modified""#),
+            line("fs", "a2", 11, r#""path":"/workspace/src/main.rs","kind_detail":"accessed""#),
+            line("status", "a1", 12, r#""status":"pulse","msg":"Transition to busy""#),
+        ]);
+        assert!(s.base.is_none(), "delta only — no rebuild yet");
+        let hits = s.search("fleet.html", &[], None, None, 10);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].agent.as_deref(), Some("a1"));
+        let hits = s.search("busy", &[], None, None, 10);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, "status");
+    }
+
+    #[test]
+    fn base_search_after_rebuild_and_newest_first_order() {
+        let mut s = EventStore::new();
+        s.rebuild_threshold = 3;
+        for i in 0..5u64 {
+            s.ingest_line(&line(
+                "fs",
+                "a1",
+                100 + i,
+                r#""path":"/workspace/report.md","kind_detail":"modified""#,
+            ));
+        }
+        assert!(s.base.is_some(), "threshold crossed — base built");
+        let hits = s.search("report.md", &[], None, None, 10);
+        assert_eq!(hits.len(), 5);
+        assert!(hits.windows(2).all(|w| w[0].ts >= w[1].ts), "newest first");
+    }
+
+    #[test]
+    fn filters_kind_agent_since_and_limit() {
+        let s = store_with(&[
+            line("fs", "a1", 10, r#""path":"/w/x.rs","kind_detail":"accessed""#),
+            line("fs", "a2", 20, r#""path":"/w/x.rs","kind_detail":"modified""#),
+            line("status", "a2", 30, r#""msg":"x.rs compiled""#),
+        ]);
+        let hits = s.search("x.rs", &["fs".into()], None, None, 10);
+        assert_eq!(hits.len(), 2);
+        let hits = s.search("x.rs", &[], Some("a2"), None, 10);
+        assert_eq!(hits.len(), 2);
+        let hits = s.search("x.rs", &[], None, Some(15), 10);
+        assert_eq!(hits.len(), 2);
+        let hits = s.search("x.rs", &[], None, None, 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].ts, 30);
+    }
+
+    #[test]
+    fn bulk_ingest_builds_base_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("events.jsonl");
+        let mut body = String::new();
+        for i in 0..50u64 {
+            body.push_str(&line("fs", "a1", i, r#""path":"/w/deep/file.txt","kind_detail":"accessed""#));
+            body.push('\n');
+            body.push_str(&line("metric", "a1", i, r#""cpu_pct":1"#));
+            body.push('\n');
+        }
+        std::fs::write(&p, body).unwrap();
+        let mut s = EventStore::new();
+        let added = s.ingest_file(&p).unwrap();
+        assert_eq!(added, 50, "metrics excluded");
+        assert!(s.base.is_some());
+        assert_eq!(s.base_len, 50);
+        let hits = s.search("file.txt", &[], None, None, 100);
+        assert_eq!(hits.len(), 50);
+    }
+}

--- a/src/event_store.rs
+++ b/src/event_store.rs
@@ -21,6 +21,24 @@
 
 use lume::bm25::{Bm25Index, Bm25Params, SearchVariant, Section};
 
+/// Heuristic: does this string look like binary data that leaked into a text
+/// field (U+FFFD replacement chars, control bytes, symbol soup)? Used to keep
+/// garbage out of the search corpus and to collapse it in the UI.
+pub fn looks_binary(s: &str) -> bool {
+    if s.len() < 24 {
+        return false;
+    }
+    let mut bad = 0usize;
+    let mut total = 0usize;
+    for c in s.chars().take(400) {
+        total += 1;
+        if c == '\u{FFFD}' || (c.is_control() && c != '\n' && c != '\t' && c != '\r') {
+            bad += 1;
+        }
+    }
+    total > 0 && bad * 100 / total >= 15
+}
+
 /// Rebuild the base index when the delta tail exceeds this many docs.
 const DEFAULT_REBUILD_THRESHOLD: usize = 2_000;
 /// Hard corpus cap — beyond this the oldest half is dropped (the files
@@ -103,6 +121,18 @@ impl EventStore {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
             return false;
         };
+        self.push_value(v)
+    }
+
+    /// Ingest an already-parsed event (synthesized events — tool_call etc. —
+    /// enter here). Triggers a base rebuild when the delta is due.
+    pub fn ingest_value(&mut self, v: serde_json::Value) {
+        if self.push_value(v) {
+            self.maybe_rebuild();
+        }
+    }
+
+    fn push_value(&mut self, v: serde_json::Value) -> bool {
         let kind = v
             .get("kind")
             .and_then(|k| k.as_str())
@@ -137,6 +167,11 @@ impl EventStore {
                     continue;
                 }
                 if let Some(s) = val.as_str() {
+                    // Binary spew (a tailer that ate a non-text file) would
+                    // poison the corpus — don't index it.
+                    if looks_binary(s) {
+                        continue;
+                    }
                     text.push(' ');
                     text.push_str(s);
                     if s.contains(['-', '_']) {

--- a/src/event_store.rs
+++ b/src/event_store.rs
@@ -15,14 +15,12 @@
 //! kind/agent/since, ordered newest-first — Splunk semantics: time-ordered
 //! matches, relevance decides membership, not order.
 //!
-//! `metric` and `heartbeat` events are NOT indexed — they are chart fodder
-//! (2/3 of the stream, no searchable text). Kind-filtered queries for them
-//! fall back to the ring upstream.
+//! EVERY kind is indexed — including metric and heartbeat: "q=<agent name>"
+//! must surface everything a container is doing (its metrics, heartbeats,
+//! and file access included). Identity searchability beats corpus thrift.
 
 use lume::bm25::{Bm25Index, Bm25Params, SearchVariant, Section};
 
-/// Kinds that never enter the search corpus.
-const EXCLUDED_KINDS: &[&str] = &["metric", "heartbeat"];
 /// Rebuild the base index when the delta tail exceeds this many docs.
 const DEFAULT_REBUILD_THRESHOLD: usize = 2_000;
 /// Hard corpus cap — beyond this the oldest half is dropped (the files
@@ -110,9 +108,6 @@ impl EventStore {
             .and_then(|k| k.as_str())
             .unwrap_or("event")
             .to_string();
-        if EXCLUDED_KINDS.contains(&kind.as_str()) {
-            return false;
-        }
         let agent = v
             .get("agent_id")
             .and_then(|a| a.as_str())
@@ -127,6 +122,15 @@ impl EventStore {
             text.push(' ');
             text.push_str(a);
         }
+        // lume folds "-" by JOINING (n8-noble-otter -> one token), so also
+        // index a space-split variant of every hyphen/underscore value —
+        // "otter" or "noble otter" must find the container.
+        if let Some(a) = &agent {
+            if a.contains(['-', '_']) {
+                text.push(' ');
+                text.push_str(&a.replace(['-', '_'], " "));
+            }
+        }
         if let Some(obj) = v.as_object() {
             for (k, val) in obj {
                 if k == "agent_id" || k == "kind" {
@@ -135,6 +139,10 @@ impl EventStore {
                 if let Some(s) = val.as_str() {
                     text.push(' ');
                     text.push_str(s);
+                    if s.contains(['-', '_']) {
+                        text.push(' ');
+                        text.push_str(&s.replace(['-', '_'], " "));
+                    }
                 }
             }
         }
@@ -196,6 +204,11 @@ impl EventStore {
         since: Option<u64>,
         limit: usize,
     ) -> Vec<&EventDoc> {
+        // Same hyphen story on the QUERY side: fold to spaces so partial
+        // identities ("noble-otter") tokenize into matchable words.
+        let q = q.replace(['-', '_'], " ");
+        let q = q.as_str();
+
         let mut idxs: Vec<usize> = Vec::new();
 
         // Base: BM25 hits map back to doc indices via Section.line_number.
@@ -257,14 +270,19 @@ mod tests {
     }
 
     #[test]
-    fn metric_and_heartbeat_are_not_indexed() {
+    fn every_kind_is_indexed_and_agent_name_finds_all_of_them() {
+        // Owner ruling: searching a container name must surface EVERYTHING it
+        // does — metrics and heartbeats and file access included.
         let s = store_with(&[
-            line("metric", "a1", 10, r#""cpu_pct":5"#),
-            line("heartbeat", "a1", 11, r#""pid":1"#),
-            line("fs", "a1", 12, r#""path":"/workspace/x.rs","kind_detail":"accessed""#),
+            line("metric", "n8-noble-otter", 10, r#""cpu_pct":5"#),
+            line("heartbeat", "n8-noble-otter", 11, r#""pid":1"#),
+            line("fs", "n8-noble-otter", 12, r#""path":"/workspace/x.rs","kind_detail":"accessed""#),
         ]);
-        assert_eq!(s.len(), 1);
-        assert_eq!(s.docs[0].kind, "fs");
+        assert_eq!(s.len(), 3);
+        let hits = s.search("noble-otter", &[], None, None, 10);
+        assert_eq!(hits.len(), 3);
+        let kinds: Vec<_> = hits.iter().map(|d| d.kind.as_str()).collect();
+        assert!(kinds.contains(&"metric") && kinds.contains(&"heartbeat") && kinds.contains(&"fs"));
     }
 
     #[test]
@@ -333,9 +351,9 @@ mod tests {
         std::fs::write(&p, body).unwrap();
         let mut s = EventStore::new();
         let added = s.ingest_file(&p).unwrap();
-        assert_eq!(added, 50, "metrics excluded");
+        assert_eq!(added, 100, "every kind indexed — metrics included");
         assert!(s.base.is_some());
-        assert_eq!(s.base_len, 50);
+        assert_eq!(s.base_len, 100);
         let hits = s.search("file.txt", &[], None, None, 100);
         assert_eq!(hits.len(), 50);
     }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1689,6 +1689,48 @@ async fn fleet_rows_from_gateway_state(
         .map(|c| container_summary_to_fleet_container(c, now))
         .collect();
 
+    // Synthesize tool_call events (who called what, with which params) by
+    // tailing each container's resolved session transcript — into the ring,
+    // the lume store, and the SSE stream, so they behave like native events.
+    {
+        let mut tailer = state
+            .telemetry
+            .tool_tailer
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let mut synthesized: Vec<serde_json::Value> = Vec::new();
+        for c in &fleet_containers {
+            let newest_session = sessions
+                .iter()
+                .filter(|s| {
+                    s.provider.as_deref() == Some(c.provider.as_str())
+                        && s.workspace.as_deref() == Some(c.workspace.as_str())
+                })
+                .max_by(|a, b| a.modified.cmp(&b.modified));
+            if let Some(s) = newest_session {
+                synthesized.extend(tailer.poll(std::path::Path::new(&s.path), &c.name));
+            }
+        }
+        drop(tailer);
+        if !synthesized.is_empty() {
+            let mut ring = state
+                .telemetry
+                .index
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let mut store = state
+                .telemetry
+                .event_store
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            for e in synthesized {
+                ring.ingest_value(e.clone());
+                store.ingest_value(e.clone());
+                let _ = state.telemetry.broadcast_tx.send(e);
+            }
+        }
+    }
+
     let index_guard = state
         .telemetry
         .index
@@ -1720,8 +1762,15 @@ fn format_fleet_event(e: &serde_json::Value) -> Option<FleetEventOut> {
         .or_else(|| e.get("op").and_then(|v| v.as_str()))
         .or_else(|| e.get("error").and_then(|v| v.as_str()))
         // Terminal-origin lines (log_line etc.) carry ANSI/control bytes —
-        // scrub with the trainer's cleaner so the feed never renders garble.
-        .map(|s| truncate(&crate::trainer_api::scrub(s), 180))
+        // scrub with the trainer's cleaner; if the content is BINARY spew (a
+        // tailed non-text file), say so honestly instead of rendering soup.
+        .map(|s| {
+            if crate::event_store::looks_binary(s) {
+                format!("[binary content — {} chars, not renderable]", s.chars().count())
+            } else {
+                truncate(&crate::trainer_api::scrub(s), 180)
+            }
+        })
         .unwrap_or_else(|| {
             if kind == "metric" {
                 let cpu = get_f64(e, "cpu_pct");

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1733,7 +1733,7 @@ async fn fleet_rows_from_gateway_state(
                 tracing::debug!(agent = %c.name, provider = %c.provider, workspace = %c.workspace, "tool tailer: no session matched");
             }
         }
-        tracing::info!(count = synthesized.len(), "tool tailer synthesized events");
+        tracing::debug!(count = synthesized.len(), "tool tailer synthesized events");
         drop(tailer);
         if !synthesized.is_empty() {
             let mut ring = state

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1540,11 +1540,31 @@ fn container_summary_to_fleet_container(
         .and_then(|l| l.get(crate::docker::LABEL_MODEL))
         .cloned()
         .unwrap_or_default();
+    // Workspace: the label (0.18.12+ launches), FALLING BACK to the project
+    // bind mount for containers started by older binaries — same rule the
+    // control room uses. Without this, the session join (tok/s, tool_call
+    // tailing) silently skips every pre-label container.
     let workspace = c
         .labels
         .as_ref()
         .and_then(|l| l.get(crate::docker::LABEL_WORKSPACE))
         .cloned()
+        .filter(|w| !w.is_empty())
+        .or_else(|| {
+            c.mounts.as_ref().and_then(|mounts| {
+                mounts
+                    .iter()
+                    .find(|m| {
+                        m.destination
+                            .as_deref()
+                            .map(|d| d.starts_with("/workspace/"))
+                            .unwrap_or(false)
+                    })
+                    .and_then(|m| m.source.clone())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| crate::docker::from_docker_path(&s))
+            })
+        })
         .unwrap_or_default();
     let state = c.state.clone().unwrap_or_default();
     let created = c.created.unwrap_or(0);
@@ -1709,8 +1729,11 @@ async fn fleet_rows_from_gateway_state(
                 .max_by(|a, b| a.modified.cmp(&b.modified));
             if let Some(s) = newest_session {
                 synthesized.extend(tailer.poll(std::path::Path::new(&s.path), &c.name));
+            } else {
+                tracing::debug!(agent = %c.name, provider = %c.provider, workspace = %c.workspace, "tool tailer: no session matched");
             }
         }
+        tracing::info!(count = synthesized.len(), "tool tailer synthesized events");
         drop(tailer);
         if !synthesized.is_empty() {
             let mut ring = state

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1817,13 +1817,29 @@ async fn fleet_data(
         .unwrap_or_default();
 
     let net = crate::telemetry::agent_net_stats(&index_guard, FLEET_NET_WINDOW);
-    let events = build_fleet_events(
-        &index_guard,
-        FLEET_EVENT_LIMIT,
-        params.q,
-        kinds_vec,
-        params.agent,
-    );
+    // Query routing (#79): text search → the lume store (ranked, full
+    // history); no query → the live ring.
+    let events = match params.q.as_deref().map(str::trim).filter(|q| !q.is_empty()) {
+        Some(q) => {
+            let store = state
+                .telemetry
+                .event_store
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            store
+                .search(q, &kinds_vec, params.agent.as_deref(), None, FLEET_EVENT_LIMIT)
+                .into_iter()
+                .filter_map(|d| format_fleet_event(&d.raw))
+                .collect()
+        }
+        None => build_fleet_events(
+            &index_guard,
+            FLEET_EVENT_LIMIT,
+            None,
+            kinds_vec,
+            params.agent,
+        ),
+    };
     let health = crate::telemetry::health(&index_guard, &state.telemetry.events_path);
 
     Ok(Json(FleetData {
@@ -2083,26 +2099,47 @@ async fn mcp_handler(
                         .unwrap_or(100);
 
                     state.telemetry.refresh();
-                    let index_guard = state
-                        .telemetry
-                        .index
-                        .lock()
-                        .unwrap_or_else(|p| p.into_inner());
-                    let query = crate::event_index::EventQuery {
-                        kinds: arg_kinds,
-                        since: arg_since,
-                        until: None,
-                        text: arg_q,
-                        limit: usize::MAX,
+                    // Query routing (#79): a text query goes to the lume-backed
+                    // search store (ranked membership, full history); without
+                    // one, the live ring answers (recent, instant).
+                    let raw_events: Vec<serde_json::Value> = match arg_q
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|q| !q.is_empty())
+                    {
+                        Some(q) => {
+                            let store = state
+                                .telemetry
+                                .event_store
+                                .lock()
+                                .unwrap_or_else(|p| p.into_inner());
+                            store
+                                .search(q, &arg_kinds, arg_agent_id.as_deref(), arg_since, arg_limit)
+                                .into_iter()
+                                .map(|d| d.raw.clone())
+                                .collect()
+                        }
+                        None => {
+                            let index_guard = state
+                                .telemetry
+                                .index
+                                .lock()
+                                .unwrap_or_else(|p| p.into_inner());
+                            let query = crate::event_index::EventQuery {
+                                kinds: arg_kinds,
+                                since: arg_since,
+                                until: None,
+                                text: None,
+                                limit: usize::MAX,
+                            };
+                            let mut events = index_guard.query(&query);
+                            if let Some(ref target_agent_id) = arg_agent_id {
+                                events.retain(|e| e.agent_id.as_ref() == Some(target_agent_id));
+                            }
+                            events.truncate(arg_limit);
+                            events.iter().map(|e| e.raw.clone()).collect()
+                        }
                     };
-                    let mut events = index_guard.query(&query);
-                    if let Some(ref target_agent_id) = arg_agent_id {
-                        events.retain(|e| e.agent_id.as_ref() == Some(target_agent_id));
-                    }
-                    events.truncate(arg_limit);
-
-                    let raw_events: Vec<serde_json::Value> =
-                        events.iter().map(|e| e.raw.clone()).collect();
                     let result = serde_json::json!({
                         "content": [
                             {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1719,7 +1719,9 @@ fn format_fleet_event(e: &serde_json::Value) -> Option<FleetEventOut> {
         .or_else(|| e.get("path").and_then(|v| v.as_str()))
         .or_else(|| e.get("op").and_then(|v| v.as_str()))
         .or_else(|| e.get("error").and_then(|v| v.as_str()))
-        .map(|s| truncate(s, 180))
+        // Terminal-origin lines (log_line etc.) carry ANSI/control bytes —
+        // scrub with the trainer's cleaner so the feed never renders garble.
+        .map(|s| truncate(&crate::trainer_api::scrub(s), 180))
         .unwrap_or_else(|| {
             if kind == "metric" {
                 let cpu = get_f64(e, "cpu_pct");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod activity;
 pub mod pulse;
 pub mod collectors;
 pub mod event_index;
+pub mod event_store;
 pub mod logpane;
 pub mod trainer_api;
 pub mod transcript;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod collectors;
 pub mod event_index;
 pub mod event_store;
 pub mod logpane;
+pub mod tool_events;
 pub mod trainer_api;
 pub mod transcript;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1906,7 +1906,49 @@ async fn resolve_gpu(docker: &DockerOps, requested: bool) -> bool {
 /// Authoritative source is the image's `/opt/mcp-source` (exactly what a session
 /// loads); falls back to the host tools dir when the image isn't built yet or
 /// the runtime is unreachable. Returns sorted, de-duplicated `*.py` filenames.
+///
+/// CACHED per image ID: probing the image needs a momentary `docker run --rm`
+/// (the flicker container visible at every launch). The image digest comes
+/// from `image inspect` — no container — so the probe runs ONCE per built
+/// image and every later launch reads the cache.
 fn gather_available_tools(runtime: &str, image: &str, fallback_dir: &std::path::Path) -> Vec<String> {
+    let cache_path = nemesis8::paths::nemesis_root().join("tools-cache.json");
+    let image_id = std::process::Command::new(runtime)
+        .args(["image", "inspect", "-f", "{{.Id}}", image])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !image_id.is_empty() {
+        if let Ok(raw) = std::fs::read_to_string(&cache_path) {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) {
+                if v.get("image_id").and_then(|i| i.as_str()) == Some(image_id.as_str()) {
+                    if let Some(tools) = v.get("tools").and_then(|t| t.as_array()) {
+                        return tools
+                            .iter()
+                            .filter_map(|t| t.as_str().map(String::from))
+                            .collect();
+                    }
+                }
+            }
+        }
+    }
+    let tools = gather_available_tools_probe(runtime, image, fallback_dir);
+    if !image_id.is_empty() && !tools.is_empty() {
+        let _ = std::fs::write(
+            &cache_path,
+            serde_json::json!({ "image_id": image_id, "tools": tools }).to_string(),
+        );
+    }
+    tools
+}
+
+fn gather_available_tools_probe(
+    runtime: &str,
+    image: &str,
+    fallback_dir: &std::path::Path,
+) -> Vec<String> {
     let out = std::process::Command::new(runtime)
         .args([
             "run",

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -16,6 +16,9 @@ pub struct TelemetryState {
     pub broadcast_tx: tokio::sync::broadcast::Sender<serde_json::Value>,
     pub token_cache: Arc<Mutex<std::collections::HashMap<String, (std::time::SystemTime, u64)>>>,
     pub net_cache: Arc<Mutex<std::collections::HashMap<String, (u64, u64, u64)>>>,
+    /// Lume-backed SEARCH corpus (#79). The ring above serves the live jobs;
+    /// any query with `q` routes here for ranked, full-history retrieval.
+    pub event_store: Arc<Mutex<crate::event_store::EventStore>>,
 }
 
 impl TelemetryState {
@@ -37,6 +40,7 @@ impl TelemetryState {
             broadcast_tx: tx,
             token_cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
             net_cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            event_store: Arc::new(Mutex::new(crate::event_store::EventStore::new())),
         }
     }
 
@@ -88,16 +92,41 @@ impl TelemetryState {
             let mut index_guard = self.index.lock().unwrap_or_else(|p| p.into_inner());
             *index_guard = new_index;
 
-            // Broadcast newly-ingested events
+            // Broadcast newly-ingested events + feed the SEARCH store.
             if old_size > 0 && e_size > old_size {
                 if let Ok(new_lines) = read_range(&self.events_path, old_size, e_size) {
+                    let mut store = self
+                        .event_store
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
                     for line in new_lines.lines() {
                         let line = line.trim();
                         if !line.is_empty() {
+                            store.ingest_line(line);
                             if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
                                 let _ = self.broadcast_tx.send(v);
                             }
                         }
+                    }
+                }
+            } else if old_size == 0 {
+                // First refresh after start: bulk-load the whole history into
+                // the search store (sibling first — it holds the OLDER events
+                // — then the live file). One base build per file, never O(n²).
+                let mut store = self
+                    .event_store
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner());
+                if store.is_empty() {
+                    let mut loaded = 0usize;
+                    if s_mtime.is_some() {
+                        loaded += store.ingest_file(&self.sibling_path).unwrap_or(0);
+                    }
+                    if e_mtime.is_some() {
+                        loaded += store.ingest_file(&self.events_path).unwrap_or(0);
+                    }
+                    if loaded > 0 {
+                        tracing::info!(docs = loaded, "event search store loaded (lume)");
                     }
                 }
             }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -19,6 +19,9 @@ pub struct TelemetryState {
     /// Lume-backed SEARCH corpus (#79). The ring above serves the live jobs;
     /// any query with `q` routes here for ranked, full-history retrieval.
     pub event_store: Arc<Mutex<crate::event_store::EventStore>>,
+    /// Session-transcript tailer synthesizing `tool_call` events (who called
+    /// what, with which params) into the pipeline. Polled with the fleet join.
+    pub tool_tailer: Arc<Mutex<crate::tool_events::ToolCallTailer>>,
 }
 
 impl TelemetryState {
@@ -41,6 +44,7 @@ impl TelemetryState {
             token_cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
             net_cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
             event_store: Arc::new(Mutex::new(crate::event_store::EventStore::new())),
+            tool_tailer: Arc::new(Mutex::new(crate::tool_events::ToolCallTailer::new())),
         }
     }
 

--- a/src/tool_events.rs
+++ b/src/tool_events.rs
@@ -1,0 +1,193 @@
+//! Tool-call events for the fleet feed — WHO called WHAT with WHICH params.
+//!
+//! Agents' session transcripts (the JSONL most providers write) carry every
+//! `tool_use` block: tool name + full arguments. This tailer follows each
+//! running container's resolved session file (the same container→session
+//! correlation the fleet's tok/s uses) and synthesizes a `tool_call` event
+//! per invocation into the normal event pipeline — ring, lume store, SSE —
+//! so the dashboard/kind-filter/search treat them like any other event.
+//!
+//! Host-side only: no container or monitor changes, works for sessions that
+//! are already running.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// How much of a fresh file to replay on first sight, so the feed seeds with
+/// RECENT calls instead of starting empty (or flooding with megabytes).
+const SEED_BYTES: u64 = 64 * 1024;
+/// Argument preview cap in the summary line.
+const ARGS_PREVIEW: usize = 220;
+/// Full-arguments cap stored on the event (raw JSON string).
+const ARGS_FULL_CAP: usize = 4_000;
+
+#[derive(Default)]
+pub struct ToolCallTailer {
+    offsets: HashMap<PathBuf, u64>,
+}
+
+impl ToolCallTailer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Tail newly-appended lines of `session_path`, returning one synthesized
+    /// `tool_call` event per `tool_use` block, attributed to `agent_id`.
+    pub fn poll(
+        &mut self,
+        session_path: &Path,
+        agent_id: &str,
+    ) -> Vec<serde_json::Value> {
+        let Ok(meta) = std::fs::metadata(session_path) else {
+            return Vec::new();
+        };
+        let size = meta.len();
+        let start = match self.offsets.get(session_path).copied() {
+            Some(prev) if prev <= size => prev,
+            // First sight (or truncation): seed from the recent tail only.
+            _ => size.saturating_sub(SEED_BYTES),
+        };
+        self.offsets.insert(session_path.to_path_buf(), size);
+        if size <= start {
+            return Vec::new();
+        }
+        let Ok(chunk) = read_range(session_path, start, size) else {
+            return Vec::new();
+        };
+
+        let mut out = Vec::new();
+        for line in chunk.lines() {
+            // If we started mid-file the first line may be partial — a failed
+            // JSON parse just skips it.
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+                continue;
+            };
+            if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+                continue;
+            }
+            let ts = v
+                .get("timestamp")
+                .and_then(|t| t.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.timestamp() as u64)
+                .unwrap_or(0);
+            let Some(items) = v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+            else {
+                continue;
+            };
+            for item in items {
+                if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                    continue;
+                }
+                let Some(name) = item.get("name").and_then(|n| n.as_str()) else {
+                    continue;
+                };
+                let input = item.get("input").cloned().unwrap_or(serde_json::json!({}));
+                let args_json = serde_json::to_string(&input).unwrap_or_default();
+                let args_full = truncate_chars(&args_json, ARGS_FULL_CAP);
+                let preview = truncate_chars(&args_json, ARGS_PREVIEW);
+                out.push(serde_json::json!({
+                    "kind": "tool_call",
+                    "agent_id": agent_id,
+                    "ts": ts,
+                    "tool": name,
+                    "summary": format!("{name} {preview}"),
+                    "args": args_full,
+                }));
+            }
+        }
+        out
+    }
+}
+
+fn truncate_chars(s: &str, cap: usize) -> String {
+    if s.chars().count() <= cap {
+        s.to_string()
+    } else {
+        let mut t: String = s.chars().take(cap).collect();
+        t.push('…');
+        t
+    }
+}
+
+fn read_range(path: &Path, start: u64, end: u64) -> std::io::Result<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(path)?;
+    f.seek(SeekFrom::Start(start))?;
+    let mut buf = vec![0u8; (end - start) as usize];
+    f.read_exact(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn assistant_line(ts: &str, tool: &str, args: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","timestamp":"{ts}","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"t1","name":"{tool}","input":{args}}}]}}}}"#
+        )
+    }
+
+    #[test]
+    fn emits_tool_calls_with_name_args_and_attribution() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("session.jsonl");
+        std::fs::write(&p, "").unwrap();
+
+        let mut tailer = ToolCallTailer::new();
+        // First poll on the empty file: seeds offsets, emits nothing.
+        assert!(tailer.poll(&p, "n8-noble-otter").is_empty());
+
+        let mut f = std::fs::OpenOptions::new().append(true).open(&p).unwrap();
+        writeln!(
+            f,
+            "{}",
+            assistant_line(
+                "2026-07-07T14:00:00Z",
+                "mcp__hyperia__terminal_run",
+                r#"{"command":"ls -la","pane":"abc"}"#
+            )
+        )
+        .unwrap();
+        drop(f);
+
+        let events = tailer.poll(&p, "n8-noble-otter");
+        assert_eq!(events.len(), 1);
+        let e = &events[0];
+        assert_eq!(e["kind"], "tool_call");
+        assert_eq!(e["agent_id"], "n8-noble-otter");
+        assert_eq!(e["tool"], "mcp__hyperia__terminal_run");
+        assert!(e["summary"].as_str().unwrap().contains("ls -la"));
+        assert!(e["args"].as_str().unwrap().contains("\"pane\":\"abc\""));
+        assert!(e["ts"].as_u64().unwrap() > 0);
+
+        // No re-emission on an unchanged file.
+        assert!(tailer.poll(&p, "n8-noble-otter").is_empty());
+    }
+
+    #[test]
+    fn first_sight_seeds_only_the_recent_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("big.jsonl");
+        let mut body = String::new();
+        for i in 0..3000 {
+            body.push_str(&assistant_line(
+                "2026-07-07T14:00:00Z",
+                "Bash",
+                &format!(r#"{{"command":"echo {i}"}}"#),
+            ));
+            body.push('\n');
+        }
+        std::fs::write(&p, &body).unwrap();
+        let mut tailer = ToolCallTailer::new();
+        let events = tailer.poll(&p, "a1");
+        // Seeded from the last 64KB — some events, not all 3000.
+        assert!(!events.is_empty());
+        assert!(events.len() < 3000);
+    }
+}

--- a/src/tool_events.rs
+++ b/src/tool_events.rs
@@ -62,45 +62,71 @@ impl ToolCallTailer {
             let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
                 continue;
             };
-            if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
-                continue;
-            }
             let ts = v
                 .get("timestamp")
                 .and_then(|t| t.as_str())
                 .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
                 .map(|dt| dt.timestamp() as u64)
                 .unwrap_or(0);
-            let Some(items) = v
-                .get("message")
-                .and_then(|m| m.get("content"))
-                .and_then(|c| c.as_array())
-            else {
-                continue;
-            };
-            for item in items {
-                if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
-                    continue;
+
+            match v.get("type").and_then(|t| t.as_str()) {
+                // Claude/gemini-family transcripts: assistant messages carry
+                // tool_use content blocks with structured `input`.
+                Some("assistant") => {
+                    let Some(items) = v
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .and_then(|c| c.as_array())
+                    else {
+                        continue;
+                    };
+                    for item in items {
+                        if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                            continue;
+                        }
+                        let Some(name) = item.get("name").and_then(|n| n.as_str()) else {
+                            continue;
+                        };
+                        let input =
+                            item.get("input").cloned().unwrap_or(serde_json::json!({}));
+                        let args_json = serde_json::to_string(&input).unwrap_or_default();
+                        out.push(tool_call_event(agent_id, ts, name, &args_json));
+                    }
                 }
-                let Some(name) = item.get("name").and_then(|n| n.as_str()) else {
-                    continue;
-                };
-                let input = item.get("input").cloned().unwrap_or(serde_json::json!({}));
-                let args_json = serde_json::to_string(&input).unwrap_or_default();
-                let args_full = truncate_chars(&args_json, ARGS_FULL_CAP);
-                let preview = truncate_chars(&args_json, ARGS_PREVIEW);
-                out.push(serde_json::json!({
-                    "kind": "tool_call",
-                    "agent_id": agent_id,
-                    "ts": ts,
-                    "tool": name,
-                    "summary": format!("{name} {preview}"),
-                    "args": args_full,
-                }));
+                // Codex rollouts: response_item lines whose payload is a
+                // function_call — `arguments` is already a JSON string.
+                Some("response_item") => {
+                    let Some(payload) = v.get("payload") else { continue };
+                    if payload.get("type").and_then(|t| t.as_str()) != Some("function_call") {
+                        continue;
+                    }
+                    let Some(name) = payload.get("name").and_then(|n| n.as_str()) else {
+                        continue;
+                    };
+                    let args_json = payload
+                        .get("arguments")
+                        .and_then(|a| a.as_str())
+                        .unwrap_or("{}")
+                        .to_string();
+                    out.push(tool_call_event(agent_id, ts, name, &args_json));
+                }
+                _ => {}
             }
         }
         out
     }
+}
+
+fn tool_call_event(agent_id: &str, ts: u64, name: &str, args_json: &str) -> serde_json::Value {
+    let preview = truncate_chars(args_json, ARGS_PREVIEW);
+    serde_json::json!({
+        "kind": "tool_call",
+        "agent_id": agent_id,
+        "ts": ts,
+        "tool": name,
+        "summary": format!("{name} {preview}"),
+        "args": truncate_chars(args_json, ARGS_FULL_CAP),
+    })
 }
 
 fn truncate_chars(s: &str, cap: usize) -> String {
@@ -168,6 +194,27 @@ mod tests {
 
         // No re-emission on an unchanged file.
         assert!(tailer.poll(&p, "n8-noble-otter").is_empty());
+    }
+
+    #[test]
+    fn parses_codex_rollout_function_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("rollout.jsonl");
+        std::fs::write(&p, "").unwrap();
+        let mut tailer = ToolCallTailer::new();
+        tailer.poll(&p, "n8-keen-crow");
+
+        let line = r#"{"timestamp":"2026-07-07T20:32:43.040Z","type":"response_item","payload":{"type":"function_call","id":"fc_1","name":"exec_command","arguments":"{\"cmd\":\"sed -n '1,260p' PLAN.md\",\"workdir\":\"/workspace\"}","call_id":"call_x"}}"#;
+        let mut f = std::fs::OpenOptions::new().append(true).open(&p).unwrap();
+        writeln!(f, "{line}").unwrap();
+        drop(f);
+
+        let events = tailer.poll(&p, "n8-keen-crow");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["tool"], "exec_command");
+        assert_eq!(events[0]["agent_id"], "n8-keen-crow");
+        assert!(events[0]["summary"].as_str().unwrap().contains("PLAN.md"));
+        assert!(events[0]["ts"].as_u64().unwrap() > 0);
     }
 
     #[test]

--- a/web/fleet.html
+++ b/web/fleet.html
@@ -104,7 +104,8 @@
   }
   .ev:hover { background: #15191e; }
   .ev .k { font-size: 10px; text-transform: uppercase; letter-spacing: .4px; color: var(--dim); }
-  .ev .ag { color: var(--blue); overflow: hidden; text-overflow: ellipsis; }
+  .ev .ag { color: var(--blue); overflow: hidden; text-overflow: ellipsis; cursor: pointer; }
+  .ev .ag .prov { color: var(--dim); font-size: 9px; margin-left: 6px; text-transform: uppercase; letter-spacing: .5px; }
   .ev .ts { color: var(--dim); font-size: 11px; white-space: nowrap; flex-shrink: 0; }
   .ev .sm { color: var(--txt); overflow: hidden; text-overflow: ellipsis; }
   
@@ -270,6 +271,22 @@ const $events = document.getElementById("events");
 const $search = document.getElementById("ev-search");
 const $kindFilter = document.getElementById("ev-kind-filter");
 const $agentFilter = document.getElementById("ev-agent-filter");
+// Click an agent name anywhere in the feed -> filter to that agent.
+document.addEventListener("click", (ev) => {
+  const ag = ev.target.closest(".ag");
+  if (!ag || !ag.dataset.agent) return;
+  ev.stopPropagation();
+  filterAgent = ag.dataset.agent;
+  if ($agentFilter) {
+    if (![...$agentFilter.options].some(o => o.value === filterAgent)) {
+      const o = document.createElement("option");
+      o.value = filterAgent; o.textContent = filterAgent;
+      $agentFilter.appendChild(o);
+    }
+    $agentFilter.value = filterAgent;
+  }
+  reloadEventsFeed();
+}, true);
 const $btnPause = document.getElementById("btn-pause");
 const $pauseIcon = document.getElementById("pause-icon");
 const $pauseText = document.getElementById("pause-text");
@@ -357,6 +374,16 @@ function ago(ts, now){
 }
 
 function klass(kind){ return "ev k-"+String(kind||"").toLowerCase().replace(/[^a-z0-9]/g,""); }
+
+// container -> {provider, model}, refreshed from every fleet poll, so event
+// rows can say WHAT runs in the container (n8-noble-otter · antigravity).
+let agentMeta = {};
+function agentCell(agent){
+  if (!agent) return '<span class="dim">—</span>';
+  const m = agentMeta[agent];
+  const chip = m && m.provider ? `<span class="prov">${esc(m.provider)}</span>` : "";
+  return `${esc(agent)}${chip}`;
+}
 
 function debounce(fn, delay) {
   let timer = null;
@@ -510,6 +537,7 @@ function updateAgentFilterOptions(fleet) {
 }
 
 function renderFleetTable(fleet) {
+  (fleet || []).forEach(r => { if (r.agent_id) agentMeta[r.agent_id] = { provider: r.provider, model: r.model }; });
   const now = Math.floor(Date.now()/1000);
   
   // Populate agent options based on current fleet
@@ -574,7 +602,7 @@ function renderEventsList(events) {
       return `<div class="${klass(e.kind)}">
         <span class="ts">${fmtTs(e.ts)}</span>
         <span class="k">${esc(e.kind||"event")}</span>
-        <span class="ag">${e.agent?esc(e.agent):'<span class="dim">—</span>'}</span>
+        <span class="ag" data-agent="${e.agent?esc(e.agent):''}">${agentCell(e.agent)}</span>
         <span class="sm">${esc(e.summary||"")}</span>
       </div>`;
     }).join("");
@@ -609,7 +637,8 @@ function prependEventDOM(container, e) {
   
   const spanAgent = document.createElement("span");
   spanAgent.className = "ag";
-  spanAgent.innerHTML = e.agent ? esc(e.agent) : '<span class="dim">—</span>';
+  spanAgent.dataset.agent = e.agent || "";
+  spanAgent.innerHTML = agentCell(e.agent);
   
   const spanTs = document.createElement("span");
   spanTs.className = "ts";
@@ -870,7 +899,7 @@ async function fetchDetailData(agentId) {
         return `<div class="${klass(e.kind)}">
           <span class="ts">${fmtTs(e.ts)}</span>
           <span class="k">${esc(e.kind||"event")}</span>
-          <span class="ag">${e.agent?esc(e.agent):'<span class="dim">—</span>'}</span>
+          <span class="ag" data-agent="${e.agent?esc(e.agent):''}">${agentCell(e.agent)}</span>
           <span class="sm">${esc(e.summary||"")}</span>
         </div>`;
       }).join("");

--- a/web/fleet.html
+++ b/web/fleet.html
@@ -105,7 +105,7 @@
   .ev:hover { background: #15191e; }
   .ev .k { font-size: 10px; text-transform: uppercase; letter-spacing: .4px; color: var(--dim); }
   .ev .ag { color: var(--blue); overflow: hidden; text-overflow: ellipsis; }
-  .ev .ts { color: var(--dim); font-size: 11px; }
+  .ev .ts { color: var(--dim); font-size: 11px; white-space: nowrap; flex-shrink: 0; }
   .ev .sm { color: var(--txt); overflow: hidden; text-overflow: ellipsis; }
   
   .ev.k-error .k, .ev.k-failed .k { color: var(--bad); }

--- a/web/fleet.html
+++ b/web/fleet.html
@@ -98,7 +98,7 @@
 
   #events { overflow-y: auto; }
   .ev {
-    display: grid; grid-template-columns: 80px 120px 80px 1fr; gap: 8px;
+    display: grid; grid-template-columns: 152px 76px 140px 1fr; gap: 10px;
     padding: 6px 10px; border-bottom: 1px solid #14181d; font-size: 12px;
     align-items: baseline; cursor: pointer;
   }


### PR DESCRIPTION
## What

- **Lume-backed event search (#79)**: `src/event_store.rs` — two-tier BM25 (base index rebuilt per 2k docs + linear delta tail) over the full event history (~80k docs at gateway start). Query routing: `q` → lume (ranked membership, newest-first), no `q` → the live ring. Wired into MCP `agent_events` and `/fleet/data.json` (dashboard search box hits it server-side). ALL kinds indexed — searching a container name surfaces everything it does. Hyphen-aware identity search (lume folds `-` by joining; ingest indexes space-split variants, queries fold to spaces).
- **tool_call events**: `src/tool_events.rs` tails each running container's resolved session transcript (claude-family JSONL + codex rollouts) and synthesizes `tool_call` events — agent, tool name, full args (capped) — into the ring, lume store, and SSE stream. agy sessions are protobuf → #90.
- **Fleet feed fixes**: Zulu ISO timestamps first-column + deterministic sort, kind dropdown built from kinds actually present (was a hardcoded fiction), provider chips + click-to-filter on agent names, event grid columns resized, workspace mount-fallback for pre-label containers (fixed the session join: tok/s + tool tailing), absolute data.json fetch (relative URL 404'd since birth, masked by the now-deleted mock fallback).
- **Binary-content defense ×3**: LogTailer blacklists binary-looking files (container-side), event store skips binary fields at ingest, summaries collapse to `[binary content — N chars]`.
- **Picker probe cache**: the per-launch flicker container (`docker run --rm ... ls /opt/mcp-source`) now runs once per image ID.
- **Docs**: BASE.md bind-0.0.0.0 guardrail (#48).

## Verification
212/212 lib tests · zero warnings · live-verified on the running gateway (identity search across kinds, SSE frames, codex `exec_command` events with args, docker-parity metrics). Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)